### PR TITLE
Add session metadata and loader

### DIFF
--- a/python/eyehead/data_io.py
+++ b/python/eyehead/data_io.py
@@ -1,0 +1,49 @@
+"""Utility functions for loading session metadata."""
+from __future__ import annotations
+
+from pathlib import Path
+import csv
+import yaml
+from typing import Iterable, Dict, Any, List
+
+
+def load_metadata(path: str | Path | None = None) -> List[Dict[str, Any]]:
+    """Load session metadata from a YAML or CSV file.
+
+    Parameters
+    ----------
+    path : str or Path, optional
+        Path to the metadata file. If ``None`` (default), the function
+        searches for ``scripts/metadata.yaml`` relative to this module.
+
+    Returns
+    -------
+    list of dict
+        A list of metadata dictionaries, one per session.
+    """
+    if path is None:
+        path = Path(__file__).resolve().parents[1] / "scripts" / "metadata.yaml"
+    else:
+        path = Path(path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Metadata file not found: {path}")
+
+    if path.suffix in {".yaml", ".yml"}:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or []
+        if isinstance(data, dict):
+            sessions = list(data.values())
+        elif isinstance(data, list):
+            sessions = data
+        else:
+            raise ValueError("Unexpected YAML structure")
+    elif path.suffix == ".csv":
+        with path.open(newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            sessions = [dict(row) for row in reader]
+    else:
+        raise ValueError(f"Unsupported metadata file extension: {path.suffix}")
+
+    return sessions
+

--- a/python/scripts/metadata.yaml
+++ b/python/scripts/metadata.yaml
@@ -1,0 +1,20 @@
+- session_id: session1
+  subject: subj1
+  data_dir: /data/session1
+  files:
+    - eye.csv
+    - head.csv
+  calibration: calib1.json
+  parameters:
+    sample_rate: 100
+    gain: 1.2
+- session_id: session2
+  subject: subj2
+  data_dir: /data/session2
+  files:
+    - eye2.csv
+    - head2.csv
+  calibration: calib2.json
+  parameters:
+    sample_rate: 120
+    gain: 1.1


### PR DESCRIPTION
## Summary
- add `scripts/metadata.yaml` listing session metadata
- implement `load_metadata` helper to parse YAML/CSV session files

## Testing
- `pytest -q`
- `PYTHONPATH=python python - <<'PY'
from eyehead.data_io import load_metadata
print(load_metadata())
PY` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml -q` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cb63e78c832589e8962cc7bd88e4