### PR TITLE
Expose session utilities in package

### DIFF
--- a/python/eyehead/__init__.py
+++ b/python/eyehead/__init__.py
@@ -1,2 +1,20 @@
-from .functions import *
-__all__ = [name for name in dir() if not name.startswith('_')]
+"""Convenience imports for the :mod:`eyehead` package.
+
+This module re-exports commonly used session utilities so that they are
+available directly under ``eyehead`` when the package is imported.  Explicitly
+defining ``__all__`` ensures these objects are part of the public API.
+"""
+
+from .functions import (
+    SessionConfig,
+    SessionData,
+    load_session_data,
+)
+from .functions import *  # noqa: F401,F403 - re-export the remaining helpers
+
+__all__ = [
+    "SessionConfig",
+    "SessionData",
+    "load_session_data",
+]
+__all__ += [name for name in dir() if not name.startswith('_') and name not in __all__]


### PR DESCRIPTION
## Summary
- Re-export SessionConfig, SessionData, and load_session_data via `eyehead` package `__init__`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1528d21b8832586f2d507d9548ccb