### PR TITLE
Add session listing utilities for multi-session analysis

### DIFF
--- a/Python/multi_session_analysis.py
+++ b/Python/multi_session_analysis.py
@@ -1,0 +1,36 @@
+"""Example driver for running analyses across multiple sessions.
+
+This script shows how to leverage the ``session_loader`` helpers to iterate
+through available sessions. Replace the ``analyze_session`` function with the
+actual analysis routine for a single recording session.
+"""
+from __future__ import annotations
+
+from session_loader import list_sessions, list_sessions_by_type
+
+
+def analyze_session(session_name: str) -> None:
+    """Placeholder for per-session analysis.
+
+    Parameters
+    ----------
+    session_name:
+        Name of the session directory to process.
+    """
+    # In a real project, this function would load data and perform analysis.
+    print(f"Analyzing session {session_name}")
+
+
+def analyze_all_sessions(experiment_type: str | None = None) -> None:
+    """Run analysis on all sessions, optionally filtered by type."""
+    sessions = (
+        list_sessions_by_type(experiment_type)
+        if experiment_type is not None
+        else list_sessions()
+    )
+    for session in sessions:
+        analyze_session(session)
+
+
+if __name__ == "__main__":
+    analyze_all_sessions()

--- a/Python/session_loader.py
+++ b/Python/session_loader.py
@@ -1,0 +1,81 @@
+"""Utilities for discovering experiment sessions.
+
+The functions in this module scan a base data directory for session folders.
+Sessions are expected to be stored in subdirectories of ``data`` with names
+that begin with an experiment type followed by an underscore, e.g.::
+
+    headfixed_2025-06-01
+    freelymoving_2025-06-02
+
+The module exposes two convenience functions:
+
+``list_sessions``
+    Return all available session folder names.
+``list_sessions_by_type``
+    Return only the session names matching a given experiment type.
+
+The base data directory can be overridden with the environment variable
+``EHC_DATA_DIR``. If the directory does not exist, an empty list is returned.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import os
+from typing import Iterable, List
+
+# Base directory containing all recorded sessions.  Users may override this by
+# setting the ``EHC_DATA_DIR`` environment variable.
+_DATA_DIR = Path(os.environ.get("EHC_DATA_DIR", Path(__file__).resolve().parent / "data"))
+
+
+def _session_dirs(base: Path | None = None) -> Iterable[Path]:
+    """Yield session directories located under ``base``.
+
+    Parameters
+    ----------
+    base:
+        Optional path to search. When omitted, the module level ``_DATA_DIR``
+        is used. The directory is created lazily if it does not exist.
+    """
+    root = base or _DATA_DIR
+    if not root.exists():
+        return []
+    return [p for p in root.iterdir() if p.is_dir()]
+
+
+def list_sessions() -> List[str]:
+    """Return the names of all available sessions.
+
+    Returns
+    -------
+    list of str
+        Sorted list of session directory names. If the data directory is
+        missing, an empty list is returned.
+    """
+    return sorted(p.name for p in _session_dirs())
+
+
+def list_sessions_by_type(experiment_type: str) -> List[str]:
+    """Return sessions whose name matches ``experiment_type``.
+
+    Parameters
+    ----------
+    experiment_type:
+        Prefix identifying an experiment class. Session names are expected to
+        have the form ``"{experiment_type}_<details>"``. The comparison is
+        case-insensitive.
+
+    Returns
+    -------
+    list of str
+        Sorted list of session names beginning with ``experiment_type``.
+    """
+    prefix = f"{experiment_type.lower()}_"
+    return sorted(
+        name
+        for name in list_sessions()
+        if name.lower().startswith(prefix)
+    )
+
+
+__all__ = ["list_sessions", "list_sessions_by_type"]


### PR DESCRIPTION
## Summary
- add `session_loader` module with helpers to list sessions and filter by experiment type
- provide `multi_session_analysis` example script showing how to drive analyses across sessions

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1fd6784108325870a31c9849e70eb