### PR TITLE
Expand session configuration dataclass

### DIFF
--- a/Python/analysis/analyze_session.py
+++ b/Python/analysis/analyze_session.py
@@ -17,9 +17,10 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 def main(session_id: str) -> None:
     """Run the analysis for a given session identifier."""
     session = load_session(session_id)
-    folder_path = Path(session.session_path)
-    results_dir = Path(session.results_dir)
-    results_dir.mkdir(parents=True, exist_ok=True)
+    folder_path = session.folder_path
+    results_dir = session.results_dir
+    if results_dir is not None:
+        results_dir.mkdir(parents=True, exist_ok=True)
 
     # The rest of the analysis would operate on ``folder_path`` and
     # save any generated figures into ``results_dir``.  For now we simply

--- a/Python/analysis/script_after_session3.py
+++ b/Python/analysis/script_after_session3.py
@@ -16,6 +16,7 @@ from utils.session_loader import load_session
 def main(session_id: str) -> None:
     """Run the full analysis pipeline for ``session_id``."""
     config = load_session(session_id)
+    config.results_dir.mkdir(parents=True, exist_ok=True)
     data = load_session_data(config)
     eye_pos_cal = calibrate_eye_position(data, config)
 

--- a/Python/tests/test_session_loader.py
+++ b/Python/tests/test_session_loader.py
@@ -12,5 +12,5 @@ from utils.session_loader import load_session
 def test_load_session() -> None:
     cfg = load_session("session_01")
     assert cfg.session_id == "session_01"
-    assert cfg.session_path == "/data/session_01"
-    assert cfg.results_dir == "/data/session_01/results"
+    assert cfg.folder_path == Path("/data/session_01")
+    assert cfg.results_dir == Path("/data/session_01/results")


### PR DESCRIPTION
## Summary
- expose common session attributes directly on `SessionConfig`
- populate new fields when reading session manifest
- adjust analysis scripts and tests to use the explicit fields

## Testing
- `python -m pytest` *(fails: skipped, missing PyYAML dependency; install attempt blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a2203fb2d8832594e8b1bc74b81281