### PR TITLE
Default results directory when absent and clean manifest

### DIFF
--- a/Python/utils/session_loader.py
+++ b/Python/utils/session_loader.py
@@ -75,6 +75,9 @@ def load_session(session_id: str) -> SessionConfig:
 
     folder = data.get("folder_path") or data.get("session_path")
     results = data.get("results_dir")
+    if results is None and folder:
+        session_folder = Path(folder).name
+        results = Path(r"X:/Analysis/EyeHeadCoupling") / session_folder
     known_keys = {
         "session_name",
         "results_dir",

--- a/data/session_manifest.yml
+++ b/data/session_manifest.yml
@@ -2,12 +2,10 @@ sessions:
   session_01:
     experiment_type: fixation
     session_path: r"X:\Experimental_Data\EyeHeadCoupling_RatTS_server\TSh01_Paris_server\Tsh001_2025-08-06T16_40_40\\"
-    results_dir: /data/session_01/results
     subject_id: Paris
     date: 2025-08-06
   session_02:
     experiment_type: stimulation
     session_path: /data/session_02
-    results_dir: /data/session_02/results
     subject_id: subj_02
     date: 2023-06-16


### PR DESCRIPTION
## Summary
- Remove explicit `results_dir` entries from `session_manifest.yml`
- Derive a default results directory based on the session folder when none specified

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a22c7201a0832591dc9f20ab5b040c