### PR TITLE
Raise errors for missing eye marker data

### DIFF
--- a/Python/eyehead/analysis.py
+++ b/Python/eyehead/analysis.py
@@ -29,6 +29,11 @@ class SaccadeConfig:
 
 def calibrate_eye_position(data: SessionData, config: SessionConfig) -> np.ndarray:
     """Calibrate eye position using eyelid markers and gaze samples."""
+    if data.origin_of_eye_coordinate is None or data.ellipse_center_xy is None:
+        raise ValueError(
+            "Missing eye marker data: origin_of_eye_coordinate or ellipse_center_xy"
+        )
+
     oc = data.origin_of_eye_coordinate
     ec = data.ellipse_center_xy
 

--- a/Python/eyehead/io.py
+++ b/Python/eyehead/io.py
@@ -113,17 +113,21 @@ def load_session_data(config: SessionConfig) -> SessionData:
     folder = Path(config.folder_path)
     data = SessionData()
 
-    def _load_csv(name: str) -> Optional[np.ndarray]:
+    def _load_csv(name: str, *, required: bool = False) -> Optional[np.ndarray]:
         file_path = folder / f"{name}.csv"
         if not file_path.exists():
+            if required:
+                raise FileNotFoundError(f"Required file '{file_path}' not found")
             return None
         cleaned = clean_csv(str(file_path))
         return np.genfromtxt(cleaned, delimiter=",", skip_header=1)
 
     data.camera = _load_csv("camera")
     data.go = _load_csv("go")
-    data.ellipse_center_xy = _load_csv("ellipse_center_xy")
-    data.origin_of_eye_coordinate = _load_csv("origin_of_eye_coordinate")
+    data.ellipse_center_xy = _load_csv("ellipse_center_xy", required=True)
+    data.origin_of_eye_coordinate = _load_csv(
+        "origin_of_eye_coordinate", required=True
+    )
     data.torsion = _load_csv("torsion")
     data.vdaxis = _load_csv("vdaxis")
     data.imu = _load_csv("imu")


### PR DESCRIPTION
## Summary
- Validate that `origin_of_eye_coordinate` and `ellipse_center_xy` data are present before calibrating eye position.
- Add `required` flag to CSV loader and enforce essential eye-marker files.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2326667308325921a3c9209869046