### PR TITLE
Parse eye tracking CSV into dedicated attributes

### DIFF
--- a/Python/eyehead/io.py
+++ b/Python/eyehead/io.py
@@ -140,6 +140,11 @@ def load_session_data(config: SessionConfig) -> SessionData:
     data.camera = _load_csv("camera")
     data.go = _load_csv("go")
     data.ellipse_center_xy = _load_csv("ellipse_center_xy", required=True, per_eye=True)
+    if data.ellipse_center_xy is not None:
+        data.eye_frame = data.ellipse_center_xy[:, 0].astype(int)
+        data.eye_timestamp = data.ellipse_center_xy[:, 1]
+        data.eye_x = data.ellipse_center_xy[:, 2]
+        data.eye_y = data.ellipse_center_xy[:, 3]
     data.origin_of_eye_coordinate = _load_csv(
         "origin_of_eye_coordinate", required=True, per_eye=True
     )


### PR DESCRIPTION
## Summary
- Split `ellipse_center_xy` columns into `eye_frame`, `eye_timestamp`, `eye_x`, and `eye_y` to expose eye tracking data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a23f544a448325a172edfc4666e16e