### PR TITLE
Use dict access for saccade indices

### DIFF
--- a/Python/analysis/script_after_session3.py
+++ b/Python/analysis/script_after_session3.py
@@ -52,6 +52,8 @@ def main(session_id: str) -> None:
         config,
         data=data,
     )
+    indices = saccades["saccade_indices_xy"]
+    print(f"Detected {len(indices)} saccades")
     saccades["stim_frames"], stim_type = organize_stims(
         data.go_frame,
         go_dir_x=data.go_direction_x,


### PR DESCRIPTION
## Summary
- Retrieve saccade indices from `detect_saccades` results via dictionary indexing
- Log number of detected saccades in session3 analysis script

## Testing
- `cd Python && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a243f881448325b34061db920b4223