### PR TITLE
Fix torsion histogram indexing

### DIFF
--- a/Python/eyehead/analysis.py
+++ b/Python/eyehead/analysis.py
@@ -356,15 +356,17 @@ def sort_plot_saccades(
 
         if torsion_present:
             idx_buf_torsion: list[int] = []
-            sorted_pairs_theta = sorted(zip(saccade_frames_theta, saccade_indices_theta))
+            sorted_pairs_theta = sorted(
+                zip(saccade_frames_theta, range(len(saccade_indices_theta)))
+            )
             for f in frames:
                 lower_bound = max(f + plot_window[0], 0)
                 upper_bound = min(f + plot_window[-1], saccade_frames_theta.max())
-                for sf, idx in sorted_pairs_theta:
+                for sf, pos in sorted_pairs_theta:
                     if sf < lower_bound:
                         continue
                     elif sf <= upper_bound:
-                        idx_buf_torsion.append(idx)
+                        idx_buf_torsion.append(pos)
                         break
                     else:
                         break


### PR DESCRIPTION
## Summary
- Avoid IndexError in torsion histogram by indexing with torsion saccade positions instead of absolute frame numbers

## Testing
- `python Python/analysis/script_after_session3.py session_01` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68a2636a05548325be7c577c6f1251c8