### PR TITLE
Ignore vector magnitude when mapping colors

### DIFF
--- a/Python/eyehead/analysis.py
+++ b/Python/eyehead/analysis.py
@@ -257,9 +257,6 @@ def sort_plot_saccades(
     rngY = y_all.max() - y_all.min()
     X_LIM = (x_all.min() - pad * rngX, x_all.max() + pad * rngX)
     Y_LIM = (y_all.min() - pad * rngY, y_all.max() + pad * rngY)
-    abs_all = np.hypot(dx[saccade_indices_xy], dy[saccade_indices_xy])
-    max_abs = abs_all.max()
-
     angle_all = np.arctan2(dy[saccade_indices_xy], dx[saccade_indices_xy])
     n_all = len(saccade_indices_xy)
 
@@ -280,7 +277,7 @@ def sort_plot_saccades(
         f"blink_thresh = {saccade_config.blink_threshold}, blink_detection = {saccade_config.blink_detection}s\n"
     )
 
-    cols = np.array([vector_to_rgb(a, m, max_abs) for a, m in zip(angle_all, abs_all)])
+    cols = np.array([vector_to_rgb(a) for a in angle_all])
     ax_quiver.quiver(
         x_all,
         y_all,
@@ -322,7 +319,6 @@ def sort_plot_saccades(
         if idx_use.size == 0:
             continue
         ang = np.arctan2(dy[idx_use], dx[idx_use])
-        mag = np.hypot(dx[idx_use], dy[idx_use])
         n_cond = len(idx_use)
 
         fig = plt.figure(figsize=(9, 5))
@@ -338,7 +334,7 @@ def sort_plot_saccades(
         ax_q.set_ylabel("Y (°)")
         ax_q.set_title(f"{session_name}\n{eye_name} — {label} (n={n_cond})")
 
-        cols = np.array([vector_to_rgb(a, m, max_abs) for a, m in zip(ang, mag)])
+        cols = np.array([vector_to_rgb(a) for a in ang])
         ax_q.quiver(
             eye_pos[idx_use, 0],
             eye_pos[idx_use, 1],

--- a/Python/eyehead/plotting.py
+++ b/Python/eyehead/plotting.py
@@ -11,14 +11,17 @@ def rotation_matrix(angle_rad: float) -> np.ndarray:
                      [np.sin(angle_rad), np.cos(angle_rad)]])
 
 
-def vector_to_rgb(angle: float, absolute: float, max_abs: float) -> tuple[float, float, float]:
-    """Map vector angle and magnitude to an RGB colour."""
+def vector_to_rgb(angle: float) -> tuple[float, float, float]:
+    """Map a vector angle to an RGB colour.
+
+    The output colour encodes direction only; saturation and value are kept
+    constant, so the magnitude of the vector does not influence the colour
+    intensity.
+    """
     angle = angle % (2 * np.pi)
     if angle < 0:
         angle += 2 * np.pi
-    return matplotlib.colors.hsv_to_rgb((angle / (2 * np.pi),
-                                         absolute / max_abs,
-                                         absolute / max_abs))
+    return matplotlib.colors.hsv_to_rgb((angle / (2 * np.pi), 1.0, 1.0))
 
 
 def plot_angle_distribution(angle: np.ndarray, ax_polar: plt.Axes, num_bins: int = 18) -> None:


### PR DESCRIPTION
## Summary
- Map vector angles to RGB without magnitude-dependent saturation in `vector_to_rgb`
- Adjust saccade plotting to use angle-only colors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a268290a3c83258f3934aa409a4fc4