### PR TITLE
Fix torsional saccade arrows rendering

### DIFF
--- a/Python/eyehead/analysis.py
+++ b/Python/eyehead/analysis.py
@@ -381,11 +381,13 @@ def sort_plot_saccades(
             idx_use_t = np.array(idx_buf_torsion, dtype=int)
             for i in idx_use_t:
                 x, y = eye_pos[i, 0], eye_pos[i, 1]
+                end = (x + 0.5, y)
                 arrow = FancyArrowPatch(
                     (x, y),
-                    (x, y),
+                    end,
+                    arrowstyle="-|>",
                     connectionstyle=f"arc3,rad={0.3 * np.sign(dtheta[i])}",
-                    mutation_scale=10 * abs(dtheta[i]),
+                    mutation_scale=max(10 * abs(dtheta[i]), 10),
                     color="purple",
                     linewidth=1.5,
                 )


### PR DESCRIPTION
## Summary
- ensure torsional saccade arrows render by offsetting start and end points in `sort_plot_saccades`
- specify arrow style and enforce minimum mutation scale so arrowheads are visible

## Testing
- `pytest -q`
- ⚠️ Unable to run an interactive rendering demo: missing `numpy`/`matplotlib` packages (installation blocked)


------
https://chatgpt.com/codex/tasks/task_e_68a2735c704483258de165ef583b6ee7