### PR TITLE
Refine torsional saccade arrows

### DIFF
--- a/Python/eyehead/analysis.py
+++ b/Python/eyehead/analysis.py
@@ -381,13 +381,11 @@ def sort_plot_saccades(
             idx_use_t = np.array(idx_buf_torsion, dtype=int)
             for i in idx_use_t:
                 x, y = eye_pos[i, 0], eye_pos[i, 1]
-                end = (x + 0.5, y)
                 arrow = FancyArrowPatch(
                     (x, y),
-                    end,
-                    arrowstyle="-|>",
+                    (x, y),
                     connectionstyle=f"arc3,rad={0.3 * np.sign(dtheta[i])}",
-                    mutation_scale=max(10 * abs(dtheta[i]), 10),
+                    mutation_scale=10 * abs(dtheta[i]),
                     color="purple",
                     linewidth=1.5,
                 )


### PR DESCRIPTION
## Summary
- Render torsional saccade arrows without artificial x-offset
- Remove custom arrowstyle and size based purely on torsional change magnitude

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2756df6d48325b9d758f75ada6a5f