### PR TITLE
Fix FancyArrowPatch endpoint for torsion saccade plots

### DIFF
--- a/Python/eyehead/analysis.py
+++ b/Python/eyehead/analysis.py
@@ -383,7 +383,8 @@ def sort_plot_saccades(
                 x, y = eye_pos[i, 0], eye_pos[i, 1]
                 arrow = FancyArrowPatch(
                     (x, y),
-                    (x, y),
+                    (x + 1e-3, y),
+                    arrowstyle="-|>",
                     connectionstyle=f"arc3,rad={0.3 * np.sign(dtheta[i])}",
                     mutation_scale=10 * abs(dtheta[i]),
                     color="purple",


### PR DESCRIPTION
## Summary
- Ensure torsional saccades show curved arrows by giving `FancyArrowPatch` a minimal end-point offset and arrowstyle
- Preserve `connectionstyle` and `mutation_scale`

## Testing
- `pytest -q`
- Attempted to regenerate plots, but numpy is missing and installation failed due to network restrictions

------
https://chatgpt.com/codex/tasks/task_e_68a27709705c832597a5b44f1f8e4999