### PR TITLE
Add manifest-based multi-session prosaccade analysis driver

### DIFF
--- a/Python/analysis/multi_session_analysis.py
+++ b/Python/analysis/multi_session_analysis.py
@@ -1,36 +1,53 @@
-"""Example driver for running analyses across multiple sessions.
+"""Run prosaccade analysis across multiple sessions.
 
-This script shows how to leverage the ``session_loader`` helpers to iterate
-through available sessions. Replace the ``analyze_session`` function with the
-actual analysis routine for a single recording session.
+This script selects sessions from ``data/session_manifest.yml`` based on the
+requested experiment type and executes the full prosaccade analysis pipeline
+for each one.
 """
 from __future__ import annotations
 
-from utils.session_loader import list_sessions, list_sessions_by_type
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis import prosaccade_session
+from analysis.prosaccade_session import main
+
+assert main is prosaccade_session.main
 
 
-def analyze_session(session_name: str) -> None:
-    """Placeholder for per-session analysis.
+def _sessions_by_type(experiment_type: str) -> list[str]:
+    """Return session IDs matching ``experiment_type`` from the manifest."""
+    manifest_path = Path(__file__).resolve().parents[1] / "data" / "session_manifest.yml"
+    with manifest_path.open("r", encoding="utf-8") as f:
+        manifest = yaml.safe_load(f) or {}
+    sessions = manifest.get("sessions", {})
+    return [
+        session_id
+        for session_id, meta in sessions.items()
+        if meta.get("experiment_type") == experiment_type
+    ]
 
-    Parameters
-    ----------
-    session_name:
-        Name of the session directory to process.
-    """
-    # In a real project, this function would load data and perform analysis.
-    print(f"Analyzing session {session_name}")
 
-
-def analyze_all_sessions(experiment_type: str | None = None) -> None:
-    """Run analysis on all sessions, optionally filtered by type."""
-    sessions = (
-        list_sessions_by_type(experiment_type)
-        if experiment_type is not None
-        else list_sessions()
-    )
-    for session in sessions:
-        analyze_session(session)
+def analyze_all_sessions(experiment_type: str = "fixation") -> None:
+    """Run prosaccade analysis on all sessions of ``experiment_type``."""
+    for session_id in _sessions_by_type(experiment_type):
+        prosaccade_session.main(session_id)
 
 
 if __name__ == "__main__":
-    analyze_all_sessions()
+    parser = argparse.ArgumentParser(
+        description="Run analysis across sessions filtered by experiment type"
+    )
+    parser.add_argument(
+        "--experiment-type",
+        default="fixation",
+        help="Experiment type to process",
+    )
+    args = parser.parse_args()
+    analyze_all_sessions(args.experiment_type)
+


### PR DESCRIPTION
## Summary
- Add `multi_session_analysis.py` driver that parses session manifest and runs `prosaccade_session.main` for each session matching experiment type
- Support optional `--experiment-type` CLI argument (default: `fixation`)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a280b86f608325a8918a7cc10fab05