### PR TITLE
Add manifest session listing utility and update analysis usage

### DIFF
--- a/Python/analysis/multi_session_analysis.py
+++ b/Python/analysis/multi_session_analysis.py
@@ -10,32 +10,18 @@ import argparse
 import sys
 from pathlib import Path
 
-import yaml
-
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from analysis import prosaccade_session
 from analysis.prosaccade_session import main
+from utils.session_loader import list_sessions_from_manifest
 
 assert main is prosaccade_session.main
 
 
-def _sessions_by_type(experiment_type: str) -> list[str]:
-    """Return session IDs matching ``experiment_type`` from the manifest."""
-    manifest_path = Path(__file__).resolve().parents[1] / "data" / "session_manifest.yml"
-    with manifest_path.open("r", encoding="utf-8") as f:
-        manifest = yaml.safe_load(f) or {}
-    sessions = manifest.get("sessions", {})
-    return [
-        session_id
-        for session_id, meta in sessions.items()
-        if meta.get("experiment_type") == experiment_type
-    ]
-
-
 def analyze_all_sessions(experiment_type: str = "fixation") -> None:
     """Run prosaccade analysis on all sessions of ``experiment_type``."""
-    for session_id in _sessions_by_type(experiment_type):
+    for session_id in list_sessions_from_manifest(experiment_type):
         prosaccade_session.main(session_id)
 
 

--- a/Python/utils/session_loader.py
+++ b/Python/utils/session_loader.py
@@ -167,9 +167,46 @@ def list_sessions_by_type(experiment_type: str) -> List[str]:
     )
 
 
+def list_sessions_from_manifest(experiment_type: str) -> List[str]:
+    """Return session IDs of a given ``experiment_type`` from the manifest.
+
+    Parameters
+    ----------
+    experiment_type:
+        Type of experiment to filter sessions by. The value is compared
+        directly against the ``"experiment_type"`` field of each manifest
+        entry.
+
+    Returns
+    -------
+    list of str
+        Sorted list of session identifiers whose ``experiment_type`` matches
+        ``experiment_type``. If the manifest file is missing or empty an empty
+        list is returned.
+    """
+
+    manifest_path = (
+        Path(__file__).resolve().parent.parent.parent / "data" / "session_manifest.yml"
+    )
+
+    try:
+        with manifest_path.open("r", encoding="utf-8") as fh:
+            manifest: Dict[str, Any] = yaml.safe_load(fh) or {}
+    except FileNotFoundError:  # pragma: no cover - defensive programming
+        return []
+
+    sessions: Dict[str, Any] = manifest.get("sessions", manifest)
+    return sorted(
+        session_id
+        for session_id, meta in sessions.items()
+        if meta.get("experiment_type") == experiment_type
+    )
+
+
 __all__ = [
     "SessionConfig",
     "load_session",
     "list_sessions",
     "list_sessions_by_type",
+    "list_sessions_from_manifest",
 ]


### PR DESCRIPTION
## Summary
- add `list_sessions_from_manifest` to centralize manifest parsing and session filtering
- export new utility and use it within `multi_session_analysis.py`

## Testing
- `pytest -q` *(fails: PyYAML not installed; attempted `pip install pyyaml` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a2825055b883258cbf4d8cadf02bfa