### PR TITLE
Aggregate prosaccade session tables

### DIFF
--- a/Python/analysis/multi_session_analysis.py
+++ b/Python/analysis/multi_session_analysis.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+import pandas as pd
+
 from analysis import prosaccade_session
 from analysis.prosaccade_session import main
 from utils.session_loader import list_sessions_from_manifest
@@ -19,10 +21,23 @@ from utils.session_loader import list_sessions_from_manifest
 assert main is prosaccade_session.main
 
 
-def analyze_all_sessions(experiment_type: str = "fixation") -> None:
-    """Run prosaccade analysis on all sessions of ``experiment_type``."""
+def analyze_all_sessions(experiment_type: str = "fixation") -> pd.DataFrame:
+    """Run prosaccade analysis on all sessions of ``experiment_type``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Concatenated results from all processed sessions.  If no sessions
+        are found, an empty :class:`~pandas.DataFrame` is returned.
+    """
+    tables: list[pd.DataFrame] = []
     for session_id in list_sessions_from_manifest(experiment_type):
-        prosaccade_session.main(session_id)
+        session_df = prosaccade_session.main(session_id)
+        tables.append(session_df)
+
+    if not tables:
+        return pd.DataFrame()
+    return pd.concat(tables, ignore_index=True)
 
 
 if __name__ == "__main__":
@@ -35,5 +50,6 @@ if __name__ == "__main__":
         help="Experiment type to process",
     )
     args = parser.parse_args()
-    analyze_all_sessions(args.experiment_type)
+    aggregated = analyze_all_sessions(args.experiment_type)
+    aggregated.to_csv("multi_session_results.csv", index=False)
 


### PR DESCRIPTION
## Summary
- Collect DataFrames returned from individual prosaccade session analyses.
- Concatenate results into a single aggregated table and save it to `multi_session_results.csv`.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a28f63f2948325b7cb4277de22f8b4