### PR TITLE
Add fixation population analysis script

### DIFF
--- a/Python/analysis/fixation_population.py
+++ b/Python/analysis/fixation_population.py
@@ -1,0 +1,54 @@
+"""Run fixation analysis across multiple sessions.
+
+This script selects sessions from ``data/session_manifest.yml`` based on the
+requested experiment type and executes the full fixation analysis pipeline
+for each one.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+
+from analysis import fixation_session
+from analysis.fixation_session import main
+from utils.session_loader import list_sessions_from_manifest
+
+assert main is fixation_session.main
+
+
+def analyze_all_sessions(experiment_type: str = "fixation") -> pd.DataFrame:
+    """Run fixation analysis on all sessions of ``experiment_type``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Concatenated results from all processed sessions. If no sessions
+        are found, an empty :class:`~pandas.DataFrame` is returned.
+    """
+    tables: list[pd.DataFrame] = []
+    for session_id in list_sessions_from_manifest(experiment_type):
+        session_df = fixation_session.main(session_id)
+        tables.append(session_df)
+
+    if not tables:
+        return pd.DataFrame()
+    return pd.concat(tables, ignore_index=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run analysis across sessions filtered by experiment type",
+    )
+    parser.add_argument(
+        "--experiment-type",
+        default="fixation",
+        help="Experiment type to process",
+    )
+    args = parser.parse_args()
+    aggregated = analyze_all_sessions(args.experiment_type)
+    aggregated.to_csv("fixation_population_results.csv", index=False)


### PR DESCRIPTION
## Summary
- Add `analysis/fixation_population.py` to process fixation sessions across all sessions of an experiment type
- Aggregate per-session results into a single CSV file
- Provide CLI `--experiment-type` option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a29d9df79c832587c8fceaefdd0c74