### PR TITLE
Handle optional arrays in fixation analysis

### DIFF
--- a/Python/analysis/fixation_session.py
+++ b/Python/analysis/fixation_session.py
@@ -47,10 +47,11 @@ def main(session_id: str) -> pd.DataFrame:
         data=data,
     )
 
-    trial_success = data.trial_success or np.array([])
+    trial_success = data.trial_success if data.trial_success is not None else np.array([])
     eye_position_during_fixation = []
     eye_position_during_fixation_success = []
-    for i, gf in enumerate((data.go_frame or [])[: len(trial_success)]):
+    go_frames = data.go_frame if data.go_frame is not None else np.array([])
+    for i, gf in enumerate(go_frames[: len(trial_success)]):
         idx = np.where(data.eye_frame < gf)[0]
         if idx.size < 7:
             continue


### PR DESCRIPTION
## Summary
- Guard against `None` in fixation_session trial and go frame data
- Iterate over explicit go frame array to avoid ambiguous truth evaluation

## Testing
- `python analysis/fixation_session.py session_01` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2a51f3b9c83259e8f04d34c9656cf