### PR TITLE
Add optional plotting to saccade detection

### DIFF
--- a/Python/analysis/fixation_session.py
+++ b/Python/analysis/fixation_session.py
@@ -39,13 +39,16 @@ def main(session_id: str) -> pd.DataFrame:
         saccade_win=0.7,
     )
 
-    saccades = detect_saccades(
+    saccades, fig_saccades, _ = detect_saccades(
         eye_pos_cal,
         data.eye_frame,
         saccade_cfg,
         config,
         data=data,
+        plot=True,
     )
+    plt.show()
+    plt.close(fig_saccades)
 
     pairs_cf, pairs_gf, pairs_ct, pairs_gt, pairs_dt, valid_trials, fig_pairs, _ = (
         plot_eye_fixations_between_cue_and_go_by_trial(


### PR DESCRIPTION
## Summary
- allow optional plotting in `detect_saccades` via new `plot` flag and return figures when enabled
- update fixation session analysis to request plots and manage returned figure

## Testing
- `cd Python && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a353c17b9083258ec2b08d77305acc