### PR TITLE
feat: optionally plot sorted saccades

### DIFF
--- a/Python/analysis/prosaccade_session.py
+++ b/Python/analysis/prosaccade_session.py
@@ -15,7 +15,7 @@ from eyehead import (
     detect_saccades,
     load_session_data,
     organize_stims,
-    sort_plot_saccades,
+    sort_saccades,
 )
 
 
@@ -69,7 +69,7 @@ def main(session_id: str) -> pd.DataFrame:
             "saccade_index_xy": indices,
         }
     )
-    sort_plot_saccades(config, saccade_cfg, saccades, stim_type=stim_type)
+    sort_saccades(config, saccade_cfg, saccades, stim_type=stim_type, plot=True)
     return df
 
 

--- a/Python/analysis/script_after_session2.py
+++ b/Python/analysis/script_after_session2.py
@@ -22,6 +22,7 @@ from eyehead import (
     choose_option,
     plot_eye_fixations_between_cue_and_go_by_trial,
     quantify_fixation_stability_vs_random,
+    sort_saccades,
 )
 
 from fixation_utils import (
@@ -230,15 +231,16 @@ print("Detected", len(saccades["saccade_indices_xy"]), "saccades")
 
 saccades["stim_frames"], stim_type = organize_stims(
     go_frame,
-    go_dir_x = go_direction_x,
-    go_dir_y = go_direction_y,
+    go_dir_x=go_direction_x,
+    go_dir_y=go_direction_y,
 )
 
-sort_plot_saccades(
+sort_saccades(
     SessionConfig,
     SaccadeConfig,
     saccades,
-    stim_type  = stim_type,
+    stim_type=stim_type,
+    plot=True,
 )
 
 session_path = SessionConfig.folder_path

--- a/Python/eyehead/__init__.py
+++ b/Python/eyehead/__init__.py
@@ -6,7 +6,7 @@ from .analysis import (
     calibrate_eye_position,
     detect_saccades,
     organize_stims,
-    sort_plot_saccades,
+    sort_saccades,
     plot_eye_fixations_between_cue_and_go_by_trial,
     quantify_fixation_stability_vs_random,
 )
@@ -33,7 +33,7 @@ __all__ = [
     "calibrate_eye_position",
     "detect_saccades",
     "organize_stims",
-    "sort_plot_saccades",
+    "sort_saccades",
     "plot_eye_fixations_between_cue_and_go_by_trial",
     "quantify_fixation_stability_vs_random",
     "butter_noncausal",


### PR DESCRIPTION
## Summary
- rename `sort_plot_saccades` -> `sort_saccades`
- support optional plotting via `plot=True`
- update analysis scripts to request plots explicitly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a353c231208325b60c372c3b6b879e