### PR TITLE
Ensure session scripts unpack detect_saccades tuple

### DIFF
--- a/Python/analysis/fixation_session.py
+++ b/Python/analysis/fixation_session.py
@@ -39,7 +39,7 @@ def main(session_id: str) -> pd.DataFrame:
         saccade_win=0.7,
     )
 
-    saccades, fig_saccades, _ = detect_saccades(
+    saccades, fig_saccades, ax_saccades = detect_saccades(
         eye_pos_cal,
         data.eye_frame,
         saccade_cfg,
@@ -48,7 +48,8 @@ def main(session_id: str) -> pd.DataFrame:
         plot=True,
     )
     plt.show()
-    plt.close(fig_saccades)
+    if fig_saccades is not None:
+        plt.close(fig_saccades)
 
     (
         pairs_cf,

--- a/Python/analysis/prosaccade_session.py
+++ b/Python/analysis/prosaccade_session.py
@@ -3,6 +3,7 @@ import sys
 import argparse
 from pathlib import Path
 import pandas as pd
+import matplotlib.pyplot as plt
 
 # Put the repo's “Python” folder on sys.path so `import eyehead` works
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -47,13 +48,16 @@ def main(session_id: str) -> pd.DataFrame:
         saccade_win=0.7,
     )
 
-    saccades = detect_saccades(
+    saccades, fig_saccades, _ = detect_saccades(
         eye_pos_cal,
         data.eye_frame,
         saccade_cfg,
         config,
         data=data,
+        plot=False,
     )
+    if fig_saccades is not None:
+        plt.close(fig_saccades)
     indices = saccades["saccade_indices_xy"]
     saccade_frames = saccades.get("saccade_frames_xy", [])
     print(f"Detected {len(indices)} saccades")

--- a/Python/analysis/script_after_session2.py
+++ b/Python/analysis/script_after_session2.py
@@ -217,7 +217,7 @@ eye_pos_cal = calibrate_eye_position(session_data, SessionConfig)
 
 ################################################################# detect saccades ######################################################
 ############################################################################################################################################### 
-saccades = detect_saccades(
+saccades, _, _ = detect_saccades(
     eye_pos_cal,
     eye_frame,
     SaccadeConfig,

--- a/Python/eyehead/analysis.py
+++ b/Python/eyehead/analysis.py
@@ -75,7 +75,7 @@ def detect_saccades(
     config: SessionConfig,
     data: SessionData | None = None,
     plot: bool = False,
-) -> Dict[str, np.ndarray] | Tuple[Dict[str, np.ndarray], plt.Figure, plt.Axes]:
+) -> Tuple[Dict[str, np.ndarray], Optional[plt.Figure], Optional[plt.Axes]]:
     """Detect saccades from eye tracking data.
 
     Parameters
@@ -97,9 +97,13 @@ def detect_saccades(
 
     Returns
     -------
-    Dict
-        Dictionary with detected saccade metrics.  If ``plot`` is ``True`` a
-        tuple ``(saccades, fig, ax)`` is returned instead.
+    saccades : dict
+        Dictionary with detected saccade metrics.
+    fig : Figure or None
+        Generated figure if ``plot=True``, otherwise ``None``.
+    ax : Axes or None
+        Primary axes of the diagnostic plot when ``plot=True``; ``None``
+        otherwise.
     """
     torsion_angle = None
     vd_axis_lx = vd_axis_ly = vd_axis_rx = vd_axis_ry = None
@@ -169,6 +173,7 @@ def detect_saccades(
         "saccade_frames_theta": saccade_frames_theta,
     }
 
+    fig = ax = None
     if plot:
         fig, (ax, ax2) = plt.subplots(2, 1, figsize=(12, 8), sharex=True)
         frames = np.arange(len(xy_speed))
@@ -219,9 +224,8 @@ def detect_saccades(
         )
         prob_fname = f"{session_folder}{side_tag}_saccades.png"
         fig.savefig(config.results_dir / prob_fname, dpi=300, bbox_inches="tight")
-        return saccades, fig, ax
 
-    return saccades
+    return saccades, fig, ax
 
 
 def organize_stims(


### PR DESCRIPTION
## Summary
- Capture figure and axes returned by detect_saccades in fixation and prosaccade sessions
- Close detect_saccades figures when present to avoid lingering handles

## Testing
- `cd Python && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a35c0295c48325a1d2ce117935a7d5