### PR TITLE
Add configurable saccade parameters

### DIFF
--- a/Python/analysis/fixation_session.py
+++ b/Python/analysis/fixation_session.py
@@ -31,13 +31,7 @@ def main(session_id: str) -> pd.DataFrame:
     data = load_session_data(config)
     eye_pos_cal = calibrate_eye_position(data, config)
 
-    saccade_cfg = SaccadeConfig(
-        saccade_threshold=1.0,
-        saccade_threshold_torsion=1.5,
-        blink_threshold=10.0,
-        blink_detection=1,
-        saccade_win=0.7,
-    )
+    saccade_cfg = SaccadeConfig(**config.params["saccade_config"])
 
     saccades, fig_saccades, ax_saccades = detect_saccades(
         eye_pos_cal,

--- a/Python/analysis/prosaccade_session.py
+++ b/Python/analysis/prosaccade_session.py
@@ -40,13 +40,7 @@ def main(session_id: str) -> pd.DataFrame:
     data = load_session_data(config)
     eye_pos_cal = calibrate_eye_position(data, config)
 
-    saccade_cfg = SaccadeConfig(
-        saccade_threshold=1.0,
-        saccade_threshold_torsion=1.5,
-        blink_threshold=10.0,
-        blink_detection=1,
-        saccade_win=0.7,
-    )
+    saccade_cfg = SaccadeConfig(**config.params["saccade_config"])
 
     saccades, fig_saccades, _ = detect_saccades(
         eye_pos_cal,

--- a/data/session_manifest.yml
+++ b/data/session_manifest.yml
@@ -1,18 +1,27 @@
+saccade_config:
+  saccade_threshold: 1.0
+  saccade_threshold_torsion: 1.5
+  blink_threshold: 10.0
+  blink_detection: 1
+  saccade_win: 0.7
+
 sessions:
   session_01:
     experiment_type: fixation
-    session_path: X:\Experimental_Data\EyeHeadCoupling_RatTS_server\TSh01_Paris_server\Tsh001_2025-08-06T16_40_40
+    session_path: X:\\Experimental_Data\\EyeHeadCoupling_RatTS_server\\TSh01_Paris_server\\Tsh001_2025-08-06T16_40_40
     date: 2025-08-06
     animal_name: Paris
     animal_id: Tsh001
     calibration_factor : 3.76
     ttl_freq: 60
     camera_side: L
+    params:
+      saccade_config:
+        saccade_threshold: 0.8
 
-    
   session_02:
     experiment_type: fixation
-    session_path: X:\Experimental_Data\EyeHeadCoupling_RatTS_server\TSh01_Paris_server\Tsh001_2025-08-01T15_15_48
+    session_path: X:\\Experimental_Data\\EyeHeadCoupling_RatTS_server\\TSh01_Paris_server\\Tsh001_2025-08-01T15_15_48
     date: 2025-08-01
     animal_name: Paris
     animal_id: Tsh001


### PR DESCRIPTION
## Summary
- allow global and per-session saccade configuration in `session_manifest.yml`
- merge manifest defaults with overrides in `load_session`
- build session scripts' `SaccadeConfig` from loaded config

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a36685a3f08325b47abc5d3b619419