### PR TITLE
Plot net drift across sessions with gradient colors

### DIFF
--- a/Python/analysis/fixation_population.py
+++ b/Python/analysis/fixation_population.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import yaml
 
@@ -41,6 +43,48 @@ def analyze_all_sessions(experiment_type: str = "fixation") -> pd.DataFrame:
     return pd.concat(tables, ignore_index=True)
 
 
+def plot_net_drift_trend(df: pd.DataFrame, save_dir: Path) -> None:
+    """Plot net drift across sessions using a colour gradient.
+
+    Sessions are ordered by their recording date and assigned colours from a
+    sequential colormap so that later sessions appear in a different hue than
+    earlier ones. The resulting figure is saved into ``save_dir``.
+
+    Parameters
+    ----------
+    df:
+        Aggregated fixation metrics for all sessions.
+    save_dir:
+        Directory where the plot image will be written.
+    """
+
+    if df.empty or "net_drift_fix" not in df:
+        return
+
+    data = df.copy()
+    data["session_date"] = pd.to_datetime(data["session_date"], errors="coerce")
+    data.sort_values("session_date", inplace=True)
+
+    order = np.arange(len(data))
+    cmap = plt.cm.viridis
+    colors = cmap(np.linspace(0, 1, len(data)))
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.scatter(order, data["net_drift_fix"], c=colors, s=40)
+    ax.set_xlabel("Session (earlier → later)")
+    ax.set_ylabel("Net drift during fixation (deg)")
+
+    norm = plt.Normalize(vmin=0, vmax=len(data) - 1)
+    sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap)
+    sm.set_array([])
+    cbar = fig.colorbar(sm, ax=ax)
+    cbar.set_label("Session order")
+
+    fig.tight_layout()
+    fig.savefig(save_dir / "fixation_net_drift_trend.png", dpi=300, bbox_inches="tight")
+    plt.close(fig)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Run analysis across sessions filtered by experiment type",
@@ -64,3 +108,4 @@ if __name__ == "__main__":
     aggregated.to_csv(
         results_root / "fixation_population_results.csv", index=False
     )
+    plot_net_drift_trend(aggregated, results_root)


### PR DESCRIPTION
## Summary
- Plot fixation net drift across sessions using a sequential colour gradient
- Save gradient-coloured trend plot when running fixation population analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4999bec80832594d8ce040ca4e864