### PR TITLE
feat: add error bars to fixation population plots

### DIFF
--- a/Python/analysis/fixation_population.py
+++ b/Python/analysis/fixation_population.py
@@ -70,28 +70,58 @@ def plot_metric_trends(df: pd.DataFrame, save_dir: Path) -> None:
     colors = cmap(np.linspace(0, 1, len(data)))
 
     metrics = [
-        ("mean_step_fix", "mean_step_rand", "Mean step (deg)",
-         "fixation_mean_step_trend.png"),
-        ("mean_speed_fix", "mean_speed_rand", "Mean speed (deg/s)",
-         "fixation_mean_speed_trend.png"),
-        ("net_drift_fix", "net_drift_rand", "Net drift (deg)",
-         "fixation_net_drift_trend.png"),
+        (
+            "mean_step_fix",
+            "mean_step_fix_sem",
+            "mean_step_rand",
+            "mean_step_rand_sem",
+            "Mean step (deg)",
+            "fixation_mean_step_trend.png",
+        ),
+        (
+            "mean_speed_fix",
+            "mean_speed_fix_sem",
+            "mean_speed_rand",
+            "mean_speed_rand_sem",
+            "Mean speed (deg/s)",
+            "fixation_mean_speed_trend.png",
+        ),
+        (
+            "net_drift_fix",
+            "net_drift_fix_sem",
+            "net_drift_rand",
+            "net_drift_rand_sem",
+            "Net drift (deg)",
+            "fixation_net_drift_trend.png",
+        ),
     ]
 
-    for fix_col, rand_col, ylabel, fname in metrics:
+    for fix_col, fix_sem_col, rand_col, rand_sem_col, ylabel, fname in metrics:
         if fix_col not in data or rand_col not in data:
             continue
 
         fig, ax = plt.subplots(figsize=(6, 4))
-        ax.scatter(order, data[fix_col], c=colors, s=40, label="Fixation")
-        ax.scatter(
-            order,
-            data[rand_col],
-            c=colors,
-            s=40,
-            marker="x",
-            label="Random",
-        )
+        for i, color in enumerate(colors):
+            ax.errorbar(
+                order[i],
+                data[fix_col].iloc[i],
+                yerr=data.get(fix_sem_col, pd.Series([0])).iloc[i],
+                fmt="o",
+                color=color,
+                markersize=4,
+                capsize=3,
+                label="Fixation" if i == 0 else None,
+            )
+            ax.errorbar(
+                order[i],
+                data[rand_col].iloc[i],
+                yerr=data.get(rand_sem_col, pd.Series([0])).iloc[i],
+                fmt="x",
+                color=color,
+                markersize=4,
+                capsize=3,
+                label="Random" if i == 0 else None,
+            )
         ax.set_xlabel("Session (earlier → later)")
         ax.set_ylabel(ylabel)
 

--- a/Python/analysis/fixation_session.py
+++ b/Python/analysis/fixation_session.py
@@ -93,23 +93,29 @@ def main(session_id: str) -> pd.DataFrame:
         plt.close(fig)
 
     summary = stats["summary"] if stats else {}
-    ms_fix, _, _ = summary.get("mean_step_fix_mean±sem", (np.nan, np.nan, 0))
-    ms_rnd, _, _ = summary.get("mean_step_rand_mean±sem", (np.nan, np.nan, 0))
-    sp_fix, _ = summary.get("mean_speed_fix_mean±sem", (np.nan, np.nan))
-    sp_rnd, _ = summary.get("mean_speed_rand_mean±sem", (np.nan, np.nan))
-    dr_fix, _ = summary.get("net_drift_fix_mean±sem", (np.nan, np.nan))
-    dr_rnd, _ = summary.get("net_drift_rand_mean±sem", (np.nan, np.nan))
+    ms_fix, se_fix, _ = summary.get("mean_step_fix_mean±sem", (np.nan, np.nan, 0))
+    ms_rnd, se_rnd, _ = summary.get("mean_step_rand_mean±sem", (np.nan, np.nan, 0))
+    sp_fix, se_spf = summary.get("mean_speed_fix_mean±sem", (np.nan, np.nan))
+    sp_rnd, se_spr = summary.get("mean_speed_rand_mean±sem", (np.nan, np.nan))
+    dr_fix, se_drf = summary.get("net_drift_fix_mean±sem", (np.nan, np.nan))
+    dr_rnd, se_drr = summary.get("net_drift_rand_mean±sem", (np.nan, np.nan))
 
     df = pd.DataFrame(
         {
             "session_id": [session_id],
             "session_date": [date_str],
             "mean_step_fix": [ms_fix],
+            "mean_step_fix_sem": [se_fix],
             "mean_step_rand": [ms_rnd],
+            "mean_step_rand_sem": [se_rnd],
             "mean_speed_fix": [sp_fix],
+            "mean_speed_fix_sem": [se_spf],
             "mean_speed_rand": [sp_rnd],
+            "mean_speed_rand_sem": [se_spr],
             "net_drift_fix": [dr_fix],
+            "net_drift_fix_sem": [se_drf],
             "net_drift_rand": [dr_rnd],
+            "net_drift_rand_sem": [se_drr],
             "valid_trials": [int(valid_trials.sum()) if stats else 0],
         }
     )


### PR DESCRIPTION
## Summary
- capture SEM for fixation metrics in `fixation_session`
- plot metric trends with session-matched error bars in `fixation_population`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a33af2488325ab9b28ccd4af08f5