### PR TITLE
Support prefix session type matching in manifest queries

### DIFF
--- a/Python/analysis/fixation_population.py
+++ b/Python/analysis/fixation_population.py
@@ -34,7 +34,9 @@ def analyze_all_sessions(experiment_type: str = "fixation") -> pd.DataFrame:
         are found, an empty :class:`~pandas.DataFrame` is returned.
     """
     tables: list[pd.DataFrame] = []
-    for session_id in list_sessions_from_manifest(experiment_type):
+    for session_id in list_sessions_from_manifest(
+        experiment_type, match_prefix=True
+    ):
         session_df = fixation_session.main(session_id)
         tables.append(session_df)
 

--- a/Python/analysis/prosaccade_population.py
+++ b/Python/analysis/prosaccade_population.py
@@ -32,7 +32,9 @@ def analyze_all_sessions(experiment_type: str = "prosaccade") -> pd.DataFrame:
         are found, an empty :class:`~pandas.DataFrame` is returned.
     """
     tables: list[pd.DataFrame] = []
-    for session_id in list_sessions_from_manifest(experiment_type):
+    for session_id in list_sessions_from_manifest(
+        experiment_type, match_prefix=True
+    ):
         session_df = prosaccade_session.main(session_id)
         tables.append(session_df)
 

--- a/Python/tests/test_session_loader.py
+++ b/Python/tests/test_session_loader.py
@@ -6,7 +6,7 @@ import pytest
 pytest.importorskip("yaml")
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from utils.session_loader import load_session
+from utils.session_loader import load_session, list_sessions_from_manifest
 
 
 def test_load_session() -> None:
@@ -18,3 +18,15 @@ def test_load_session() -> None:
     assert cfg.animal_id == "Tsh001"
 
     assert cfg.camera_side == "L"
+
+
+def test_list_sessions_from_manifest_exact_match() -> None:
+    sessions = list_sessions_from_manifest("fixation")
+    assert "session_01" not in sessions
+    assert "session_02" in sessions
+
+
+def test_list_sessions_from_manifest_prefix_match() -> None:
+    sessions = list_sessions_from_manifest("fixation", match_prefix=True)
+    assert "session_01" in sessions
+    assert "session_02" in sessions

--- a/Python/utils/session_loader.py
+++ b/Python/utils/session_loader.py
@@ -193,7 +193,9 @@ def list_sessions_by_type(experiment_type: str) -> List[str]:
     )
 
 
-def list_sessions_from_manifest(experiment_type: str) -> List[str]:
+def list_sessions_from_manifest(
+    experiment_type: str, match_prefix: bool = False
+) -> List[str]:
     """Return session IDs of a given ``experiment_type`` from the manifest.
 
     Parameters
@@ -202,13 +204,17 @@ def list_sessions_from_manifest(experiment_type: str) -> List[str]:
         Type of experiment to filter sessions by. The value is compared
         directly against the ``"experiment_type"`` field of each manifest
         entry.
+    match_prefix:
+        When ``True``, include sessions whose ``experiment_type`` begins with
+        ``experiment_type`` (case-insensitive).
 
     Returns
     -------
     list of str
         Sorted list of session identifiers whose ``experiment_type`` matches
-        ``experiment_type``. If the manifest file is missing or empty an empty
-        list is returned.
+        ``experiment_type``. If ``match_prefix`` is ``True`` the comparison is
+        performed using :py:meth:`str.startswith`, allowing broader matches. If
+        the manifest file is missing or empty an empty list is returned.
     """
 
     manifest_path = (
@@ -222,10 +228,18 @@ def list_sessions_from_manifest(experiment_type: str) -> List[str]:
         return []
 
     sessions: Dict[str, Any] = manifest.get("sessions", manifest)
+    exp_type_lower = experiment_type.lower()
     return sorted(
         session_id
         for session_id, meta in sessions.items()
-        if meta.get("experiment_type") == experiment_type
+        if (
+            (meta_type := meta.get("experiment_type"))
+            and (
+                meta_type.lower().startswith(exp_type_lower)
+                if match_prefix
+                else meta_type == experiment_type
+            )
+        )
     )
 
 


### PR DESCRIPTION
## Summary
- allow `list_sessions_from_manifest` to optionally match session types by prefix
- include prefix matching in fixation and prosaccade population analyses
- test exact and prefix session selection behaviors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a9a75bfc8325bccc65aed9c6ec35