### PR TITLE
Add default matplotlib style for plots

### DIFF
--- a/Python/eyehead/plotting.py
+++ b/Python/eyehead/plotting.py
@@ -1,8 +1,21 @@
+"""Plotting utilities with repository-wide style defaults.
+
+This module loads matplotlib style settings from ``Python/style.mplstyle`` so
+that all downstream figures share a consistent appearance.
+"""
+
 from __future__ import annotations
+
+from pathlib import Path
 
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
+
+
+# Apply repository style settings
+_STYLE_PATH = Path(__file__).resolve().parent.parent / "style.mplstyle"
+plt.style.use(_STYLE_PATH)
 
 
 def rotation_matrix(angle_rad: float) -> np.ndarray:

--- a/Python/style.mplstyle
+++ b/Python/style.mplstyle
@@ -1,0 +1,3 @@
+font.family: DejaVu Sans
+font.size: 12
+image.cmap: viridis

--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ Use `utils.session_loader.load_session` to access entries.
 ## Usage
 - Run analysis scripts from `Python/analysis/`.
 - Launch Jupyter notebooks from `Python/notebooks/`.
+
+## Plotting style
+Matplotlib figures use a repository-wide style defined in `Python/style.mplstyle`.
+The helper functions in `Python/eyehead/plotting.py` load this file with
+``plt.style.use`` so that all plots share consistent fonts and colours.


### PR DESCRIPTION
## Summary
- define repository-wide matplotlib defaults in `Python/style.mplstyle`
- load style in `eyehead.plotting` so helpers inherit consistent appearance
- document style file location and usage in README

## Testing
- `cd Python && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c54da708832589d08edfd25b2124