### PR TITLE
Add animal-specific session filtering for prosaccade analysis

### DIFF
--- a/Clean/Python/tests/test_session_loader.py
+++ b/Clean/Python/tests/test_session_loader.py
@@ -30,3 +30,17 @@ def test_list_sessions_from_manifest_prefix_match() -> None:
     sessions = list_sessions_from_manifest("fixation", match_prefix=True)
     assert "session_01" in sessions
     assert "session_02" in sessions
+
+
+def test_list_sessions_from_manifest_filters_by_animal() -> None:
+    sessions = list_sessions_from_manifest(
+        "prosaccade", animal_name="Paris", match_prefix=True
+    )
+    assert "session_08" in sessions
+    assert "session_09" in sessions
+
+
+def test_list_sessions_from_manifest_animal_only_filter() -> None:
+    sessions = list_sessions_from_manifest(animal_name="Paris")
+    assert "session_01" in sessions
+    assert "session_13" in sessions


### PR DESCRIPTION
## Summary
- extend the session manifest lookup helper to support optional experiment and animal filters
- propagate the new filters through the prosaccade population analysis and tag results with animal names
- add a CLI option for selecting an animal and tests that cover the new manifest filtering behaviour

## Testing
- pytest Clean/Python/tests/test_session_loader.py -rs

------
https://chatgpt.com/codex/tasks/task_e_68cf14be1af483259a1a28d51e9a3e7f