### PR TITLE
Add animal-identifying titles to prosaccade plots

### DIFF
--- a/Clean/Python/analysis/prosaccade_population.py
+++ b/Clean/Python/analysis/prosaccade_population.py
@@ -7,6 +7,7 @@ for each one.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -56,7 +57,12 @@ def analyze_all_sessions(experiment_type: str = "prosaccade") -> pd.DataFrame:
         return pd.DataFrame()
     return pd.concat(tables, ignore_index=True), left_angle_all, right_angle_all, left_angle_all_with_dates, right_angle_all_with_dates
 
-def plot_prosaccade_trends_from_dictionary(left_angle_dict: dict, right_angle_dict: dict, experiment_type: str = "prosaccade") -> None:
+def plot_prosaccade_trends_from_dictionary(
+    left_angle_dict: dict,
+    right_angle_dict: dict,
+    experiment_type: str = "prosaccade",
+    animal_label: str | None = None,
+) -> None:
 
     # Create a figure and axis
     fig, ax = plt.subplots(figsize=(10, 6))
@@ -88,15 +94,23 @@ def plot_prosaccade_trends_from_dictionary(left_angle_dict: dict, right_angle_di
     # Set plot labels and title
     ax.set_xlabel("Date")
     ax.set_ylabel("Saccade Percentage (%)")
-    ax.set_title(f"{experiment_type} Saccade Percentages Over Time")
+    title = f"{experiment_type} Saccade Percentages Over Time"
+    label_text = (str(animal_label).strip() if animal_label is not None else "")
+    animal_suffix = ""
+    if label_text:
+        title = f"{title} – {label_text}"
+        safe_label = re.sub(r"[^A-Za-z0-9_-]+", "_", label_text).strip("_")
+        if safe_label:
+            animal_suffix = f"_{safe_label}"
     ax.set_xticks(range(len(sorted_dates)))
     ax.set_xticklabels(sorted_dates, rotation=45)
+    ax.set_title(title)
     ax.legend()
     plt.tight_layout()
     plt.show()
     # Save the plot
-    fig.savefig(results_root / f"{experiment_type}_saccade_percentage_trends.png")
-    fig.savefig(results_root / f"{experiment_type}_saccade_percentage_trends.svg")
+    fig.savefig(results_root / f"{experiment_type}_saccade_percentage_trends{animal_suffix}.png")
+    fig.savefig(results_root / f"{experiment_type}_saccade_percentage_trends{animal_suffix}.svg")
 
 
 if __name__ == "__main__":
@@ -120,11 +134,40 @@ if __name__ == "__main__":
     results_root.mkdir(parents=True, exist_ok=True)
 
     ### Plot the left right angle results
-    from  eyehead.analysis import plot_left_right_angle
+    from eyehead.analysis import plot_left_right_angle
     left_angle_all = np.concatenate(left_angle_all)
     right_angle_all = np.concatenate(right_angle_all)
-    plot_left_right_angle(left_angle_all, right_angle_all, 35, sessionname=f"{args.experiment_type}_population", resultdir=results_root,experiment_type=args.experiment_type)
-    plot_prosaccade_trends_from_dictionary(left_angle_all_with_dates, right_angle_all_with_dates, experiment_type=args.experiment_type)
+    animal_label = None
+    if isinstance(aggregated, pd.DataFrame) and not aggregated.empty and "session_id" in aggregated:
+        session_ids = aggregated["session_id"].dropna().unique()
+        animal_names: list[str] = []
+        for session_id in session_ids:
+            try:
+                session_cfg = load_session(session_id)
+            except KeyError:
+                continue
+            if session_cfg.animal_name:
+                animal_names.append(session_cfg.animal_name)
+        if animal_names:
+            # Preserve manifest order while removing duplicates
+            unique_animals = list(dict.fromkeys(animal_names))
+            animal_label = ", ".join(unique_animals)
+
+    plot_left_right_angle(
+        left_angle_all,
+        right_angle_all,
+        35,
+        sessionname=f"{args.experiment_type}_population",
+        resultdir=results_root,
+        experiment_type=args.experiment_type,
+        animal_name=animal_label,
+    )
+    plot_prosaccade_trends_from_dictionary(
+        left_angle_all_with_dates,
+        right_angle_all_with_dates,
+        experiment_type=args.experiment_type,
+        animal_label=animal_label,
+    )
     aggregated.to_csv(
         results_root / f"{args.experiment_type}_population_results.csv", index=False
     )

--- a/Clean/Python/eyehead/analysis.py
+++ b/Clean/Python/eyehead/analysis.py
@@ -264,8 +264,23 @@ def organize_stims(
 
 
 #### Dirty fixes TODO
-def plot_left_right_angle(left_angle,right_angle,reward_angle=35,sessionname=None,resultdir=None,experiment_type="prosaccade"):
+def plot_left_right_angle(left_angle,right_angle,reward_angle=35,sessionname=None,resultdir=None,experiment_type="prosaccade",animal_name=None):
         fig, (ax_polar_left, ax_polar_right) = plt.subplots(1, 2, subplot_kw={'projection': 'polar'}, figsize=(15, 6))
+        context_parts = []
+        if sessionname:
+            context_parts.append(str(sessionname))
+        if experiment_type:
+            context_parts.append(str(experiment_type))
+        context_label = " | ".join(context_parts)
+        animal_label = str(animal_name).strip() if animal_name is not None else ""
+        if animal_label:
+            if context_label:
+                suptitle = f"{context_label} – Animal: {animal_label}"
+            else:
+                suptitle = f"Animal: {animal_label}"
+            fig.suptitle(suptitle)
+        elif context_label:
+            fig.suptitle(context_label)
         counts_left, bins_left = np.histogram(left_angle, bins=18, range=(-np.pi, np.pi))
         counts_right, bins_right = np.histogram(right_angle, bins=18, range=(-np.pi, np.pi))
     # Normalize the histograms
@@ -475,7 +490,7 @@ def plot_left_right_angle(left_angle,right_angle,reward_angle=35,sessionname=Non
         # ax_polar_left.set_ylim(0, np.max([np.max(counts_left), 0.4]))
         # ax_polar_right.set_ylim(0, np.max([np.max(counts_right), 0.4]))
 
-        fig.tight_layout()
+        fig.tight_layout(rect=[0, 0.03, 1, 0.95])
         cond_fname_png = f"{sessionname}_prosaccade_left_right.png"
         cond_fname_svg = f"{sessionname}_prosaccade_left_right.svg"
         fig.savefig(resultdir / cond_fname_png, dpi=300, bbox_inches="tight")
@@ -729,7 +744,15 @@ def sort_saccades(
         left_angle = np.arctan2(dy[sorted_data["Left"]], dx[sorted_data["Left"]])
         right_angle = np.arctan2(dy[sorted_data["Right"]], dx[sorted_data["Right"]])
         reward_angle = config.reward_contingency["reward_angle"]
-        plot_left_right_angle(left_angle, right_angle, reward_angle=reward_angle,sessionname=config.session_name,resultdir=config.results_dir,experiment_type=config.experiment_type)
+        plot_left_right_angle(
+            left_angle,
+            right_angle,
+            reward_angle=reward_angle,
+            sessionname=config.session_name,
+            resultdir=config.results_dir,
+            experiment_type=config.experiment_type,
+            animal_name=config.animal_name,
+        )
 
 
     if plot:


### PR DESCRIPTION
## Summary
- add optional animal labels to the population trends figure and file names
- accept an animal name in left/right angle plotting to show it in the figure suptitle
- propagate manifest animal identifiers into population and session plotting calls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf14c030148325a064184ed559bfeb