### PR TITLE
Add animal filtering support to fixation population analysis

### DIFF
--- a/Clean/Python/analysis/fixation_session.py
+++ b/Clean/Python/analysis/fixation_session.py
@@ -105,6 +105,7 @@ def main(session_id: str) -> pd.DataFrame:
     df = pd.DataFrame(
         {
             "session_id": [session_id],
+            "animal_name": [config.animal_name],
             "session_date": [date_str],
             "mean_step_fix": [ms_fix],
             "mean_step_fix_sem": [se_fix],


### PR DESCRIPTION
## Summary
- allow the fixation population analysis to filter sessions by animal and propagate the label into aggregated tables
- ensure each fixation session result carries its animal name and annotate trend plots/exports with an animal-specific suffix when provided

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf184c794c83259f82ad113e9b69ab