### PR TITLE
Include animal name tags in fixation figure outputs

### DIFF
--- a/Clean/Python/analysis/fixation_session.py
+++ b/Clean/Python/analysis/fixation_session.py
@@ -21,6 +21,7 @@ from eyehead import (
     quantify_fixation_stability_vs_random,
     get_session_date_from_path,
 )
+from eyehead.analysis import _filename_with_animal
 
 
 
@@ -68,6 +69,7 @@ def main(session_id: str) -> pd.DataFrame:
         results_dir=config.results_dir,
         animal_id=config.animal_id,
         eye_name=config.eye_name,
+        animal_name=config.animal_name,
         plot=True,
     )
     plt.show()
@@ -87,9 +89,19 @@ def main(session_id: str) -> pd.DataFrame:
 
     if stats and stats.get("figure") is not None:
         fig = stats["figure"]
-        fname = f"{config.animal_id}_{config.eye_name}_fixation_vs_random"
-        fig.savefig(config.results_dir / f"{fname}.png", bbox_inches="tight")
-        fig.savefig(config.results_dir / f"{fname}.svg", bbox_inches="tight")
+        eye_part = (config.eye_name or "Eye").replace(" ", "")
+        id_part = str(config.animal_id).strip() if config.animal_id is not None else ""
+        stem_parts = [part for part in (id_part, eye_part, "fixation_vs_random") if part]
+        stem = "_".join(stem_parts) if stem_parts else "fixation_vs_random"
+
+        base_png = f"{stem}.png"
+        base_svg = f"{stem}.svg"
+        animal_label = config.animal_name or config.animal_id
+        fname_png = _filename_with_animal(base_png, animal_label)
+        fname_svg = _filename_with_animal(base_svg, animal_label)
+
+        fig.savefig(config.results_dir / fname_png, bbox_inches="tight")
+        fig.savefig(config.results_dir / fname_svg, bbox_inches="tight")
 
         plt.show()
         plt.close(fig)

--- a/Clean/Python/eyehead/analysis.py
+++ b/Clean/Python/eyehead/analysis.py
@@ -818,6 +818,7 @@ def plot_eye_fixations_between_cue_and_go_by_trial(
     results_dir: Optional[Path] = None,
     animal_id: Optional[str] = None,
     eye_name: str = "Eye",
+    animal_name: Optional[str] = None,
     *,
     plot: bool = False,
 ) -> Tuple[
@@ -853,9 +854,11 @@ def plot_eye_fixations_between_cue_and_go_by_trial(
     results_dir : Path, optional
         If given, save the generated figure here.
     animal_id : str, optional
-        Used in the saved filename when ``results_dir`` is provided.
+        Included in the saved filename when ``results_dir`` is provided.
     eye_name : str, default "Eye"
         Label used in the saved filename.
+    animal_name : str, optional
+        Animal identifier whose normalised form is added to saved filenames.
     plot : bool, default ``False``
         When ``True``, generate a scatter plot and return figure and axes
         handles.
@@ -960,7 +963,14 @@ def plot_eye_fixations_between_cue_and_go_by_trial(
         if results_dir is not None:
             results_dir = Path(results_dir)
             results_dir.mkdir(exist_ok=True, parents=True)
-            fname = f"{animal_id}_{(eye_name or 'Eye').replace(' ', '')}_cue_go_timepaired.png"
+
+            id_part = str(animal_id).strip() if animal_id is not None else ""
+            eye_part = (eye_name or "Eye").replace(" ", "")
+            stem_parts = [part for part in (id_part, eye_part, "cue_go_timepaired") if part]
+            stem = "_".join(stem_parts) if stem_parts else "cue_go_timepaired"
+            base_fname = f"{stem}.png"
+
+            fname = _filename_with_animal(base_fname, animal_name or animal_id)
             fig.savefig(results_dir / fname, dpi=300, bbox_inches="tight")
     else:
         fig = ax = None


### PR DESCRIPTION
## Summary
- accept an optional animal name in the cue–go fixation plotting helper and fold its normalised tag into the saved filename
- pass the resolved animal name from the session runner and apply the same tag when exporting the fixation_vs_random figure

## Testing
- python -m compileall Clean/Python/eyehead/analysis.py Clean/Python/analysis/fixation_session.py

------
https://chatgpt.com/codex/tasks/task_e_68d03dfb4adc83259eeb36f95e83d218