### PR TITLE
Add CLI usage comments to analysis entry points

### DIFF
--- a/Clean/Python/analysis/fixation_population.py
+++ b/Clean/Python/analysis/fixation_population.py
@@ -193,6 +193,7 @@ def plot_metric_trends(
         plt.close(fig)
 
 
+# Usage: python Clean/Python/analysis/fixation_population.py --experiment-type fixation [--animal-name ANIMAL_NAME]
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Run analysis across sessions filtered by experiment type",

--- a/Clean/Python/analysis/fixation_session.py
+++ b/Clean/Python/analysis/fixation_session.py
@@ -125,6 +125,7 @@ def main(session_id: str) -> pd.DataFrame:
     return df
 
 
+# Usage: python Clean/Python/analysis/fixation_session.py SESSION_ID
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Analyse a recorded session for fixation metrics")
     parser.add_argument("session_id", help="Session identifier from session_manifest.yml")

--- a/Clean/Python/analysis/prosaccade_population.py
+++ b/Clean/Python/analysis/prosaccade_population.py
@@ -155,6 +155,7 @@ def plot_prosaccade_trends_from_dictionary(
     fig.savefig(results_root / f"{experiment_type}_saccade_percentage_trends{animal_suffix}.svg")
 
 
+# Usage: python Clean/Python/analysis/prosaccade_population.py --experiment-type prosaccade [--animal-name ANIMAL_NAME]
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Run analysis across sessions filtered by experiment type",

--- a/Clean/Python/analysis/prosaccade_session.py
+++ b/Clean/Python/analysis/prosaccade_session.py
@@ -104,6 +104,7 @@ def main(session_id: str, animal_name: str | None = None) -> pd.DataFrame:
     return df,left_angle,right_angle
 
 
+# Usage: python Clean/Python/analysis/prosaccade_session.py SESSION_ID [--animal-name ANIMAL_NAME]
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Analyse a recorded session")
     parser.add_argument("session_id", help="Session identifier from session_manifest.yml")


### PR DESCRIPTION
## Summary
- add inline CLI usage hints above the main entry points for the fixation and prosaccade session scripts
- document the expected command invocation for the population analysis scripts, including the optional --animal-name selector

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d03e00a614832594d1bdc059c683d6