### PR TITLE
Simplify prosaccade session entry point

### DIFF
--- a/Clean/Python/analysis/prosaccade_session.py
+++ b/Clean/Python/analysis/prosaccade_session.py
@@ -20,22 +20,15 @@ from eyehead import (
 )
 
 
-def main(session_id: str, animal_name: str | None = None) -> pd.DataFrame:
+def main(session_id: str) -> pd.DataFrame:
     """Run the full analysis pipeline for ``session_id``.
 
     Parameters
     ----------
     session_id:
         Identifier of the session to analyse.
-    animal_name:
-        Optional override for the animal label associated with the session.
-        When omitted, the value from the manifest (if present) is used.  The
-        resolved label is forwarded to downstream helpers so that generated
-        artefacts incorporate the animal tag in their filenames.
     """
     config = load_session(session_id)
-    if animal_name is not None:
-        config.animal_name = animal_name or None
     config.results_dir.mkdir(parents=True, exist_ok=True)
 
     folder_path = config.folder_path
@@ -104,16 +97,10 @@ def main(session_id: str, animal_name: str | None = None) -> pd.DataFrame:
     return df,left_angle,right_angle
 
 
-# Usage: python Clean/Python/analysis/prosaccade_session.py SESSION_ID [--animal-name ANIMAL_NAME]
+# Usage: python Clean/Python/analysis/prosaccade_session.py SESSION_ID
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Analyse a recorded session")
     parser.add_argument("session_id", help="Session identifier from session_manifest.yml")
-    parser.add_argument(
-        "--animal-name",
-        dest="animal_name",
-        default=None,
-        help="Optional override for the animal label used in generated artefacts.",
-    )
     args = parser.parse_args()
-    main(args.session_id, animal_name=args.animal_name)
+    main(args.session_id)
 


### PR DESCRIPTION
## Summary
- remove the animal name override from the prosaccade session entry point and CLI so the function only requires a session id

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d056ca4e5483259d79eeab7535389c