### PR TITLE
Revert fixation session CLI animal override

### DIFF
--- a/Clean/Python/analysis/fixation_population.py
+++ b/Clean/Python/analysis/fixation_population.py
@@ -48,9 +48,8 @@ def analyze_all_sessions(
     experiment_type:
         Experiment type used to select sessions from the manifest.
     animal_name:
-        Optional animal name used to further restrict the manifest lookup.
-        When provided, the same value is forwarded to the per-session analysis
-        so that generated artefacts share consistent animal labelling.
+        Optional animal name used to further restrict the manifest lookup and
+        annotate aggregated artefacts.
 
     Returns
     -------
@@ -62,7 +61,7 @@ def analyze_all_sessions(
     for session_id in list_sessions_from_manifest(
         experiment_type, match_prefix=True, animal_name=animal_name
     ):
-        session_df = fixation_session.main(session_id, animal_name=animal_name)
+        session_df = fixation_session.main(session_id)
 
         if "animal_name" not in session_df.columns or session_df["animal_name"].isna().all():
             session_cfg = load_session(session_id)

--- a/Clean/Python/analysis/fixation_session.py
+++ b/Clean/Python/analysis/fixation_session.py
@@ -25,21 +25,15 @@ from eyehead.analysis import _filename_with_animal
 
 
 
-def main(session_id: str, animal_name: str | None = None) -> pd.DataFrame:
+def main(session_id: str) -> pd.DataFrame:
     """Run fixation analysis for ``session_id``.
 
     Parameters
     ----------
     session_id:
         Identifier of the session to analyse.
-    animal_name:
-        Optional override for the animal label associated with the session.
-        When provided, this value is stored on the session configuration so
-        that downstream helpers incorporate it into generated artefacts.
     """
     config = load_session(session_id)
-    if animal_name is not None:
-        config.animal_name = animal_name or None
     config.results_dir.mkdir(parents=True, exist_ok=True)
 
     date_str = config.params.get("date")
@@ -153,12 +147,6 @@ def main(session_id: str, animal_name: str | None = None) -> pd.DataFrame:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Analyse a recorded session for fixation metrics")
     parser.add_argument("session_id", help="Session identifier from session_manifest.yml")
-    parser.add_argument(
-        "--animal-name",
-        dest="animal_name",
-        default=None,
-        help="Optional override for the animal label used in generated artefacts.",
-    )
     args = parser.parse_args()
-    main(args.session_id, animal_name=args.animal_name)
+    main(args.session_id)
 


### PR DESCRIPTION
## Summary
- revert the per-session fixation analysis entrypoint to accept just the session identifier and simplify its CLI
- adjust the population runner to stop forwarding the optional animal label while clarifying the docstring
- retain population-level usage of the optional animal name for filtering, filenames, and plot annotations

## Testing
- python -m compileall Clean/Python/analysis

------
https://chatgpt.com/codex/tasks/task_e_68d056c978a083258a06bdd3a0e58db5