### PR TITLE
Add valid trial ratios to fixation analysis reports

### DIFF
--- a/Clean/Python/analysis/fixation_population.py
+++ b/Clean/Python/analysis/fixation_population.py
@@ -68,6 +68,16 @@ def analyze_all_sessions(
             session_df = session_df.copy()
             session_df["animal_name"] = session_cfg.animal_name
 
+        missing_cols = [
+            col
+            for col in ("total_trials", "valid_trial_fraction")
+            if col not in session_df.columns
+        ]
+        if missing_cols:
+            session_df = session_df.copy()
+            for col in missing_cols:
+                session_df[col] = np.nan
+
         tables.append(session_df)
 
     if not tables:
@@ -187,7 +197,15 @@ def plot_metric_trends(
         interval_suffix = (
             f" – max Δt <{max_interval_s:.1f} s" if max_interval_s is not None else ""
         )
-        ax.set_title(f"{ylabel} by session{title_suffix}{interval_suffix}")
+        validity_suffix = ""
+        if "valid_trial_fraction" in data.columns:
+            valid_series = pd.to_numeric(data["valid_trial_fraction"], errors="coerce")
+            if valid_series.notna().any():
+                mean_pct = float(valid_series.mean() * 100.0)
+                validity_suffix = f" – mean valid trials {mean_pct:.0f}%"
+        ax.set_title(
+            f"{ylabel} by session{title_suffix}{interval_suffix}{validity_suffix}"
+        )
         ax.set_xlabel("Session (earlier → later)")
         ax.set_ylabel(ylabel)
 

--- a/Clean/Python/analysis/fixation_session.py
+++ b/Clean/Python/analysis/fixation_session.py
@@ -84,6 +84,13 @@ def main(session_id: str) -> pd.DataFrame:
     if fig_pairs is not None:
         plt.close(fig_pairs)
 
+    total_trials = int(valid_trials.size)
+    valid_count = int(valid_trials.sum())
+    valid_fraction = (
+        valid_count / total_trials if total_trials > 0 else np.nan
+    )
+    total_trials_value = total_trials if total_trials > 0 else np.nan
+
     stats = quantify_fixation_stability_vs_random(
         eye_timestamp=data.eye_timestamp,
         eye_pos=saccades["eye_pos"],
@@ -139,7 +146,9 @@ def main(session_id: str) -> pd.DataFrame:
             "net_drift_fix_sem": [se_drf],
             "net_drift_rand": [dr_rnd],
             "net_drift_rand_sem": [se_drr],
-            "valid_trials": [int(valid_trials.sum()) if stats else 0],
+            "valid_trials": [valid_count],
+            "total_trials": [total_trials_value],
+            "valid_trial_fraction": [valid_fraction],
         }
     )
     return df

--- a/Clean/Python/eyehead/analysis.py
+++ b/Clean/Python/eyehead/analysis.py
@@ -942,6 +942,9 @@ def plot_eye_fixations_between_cue_and_go_by_trial(
     pairs_dt = np.asarray(pairs_dt)
 
     valid_trials = (pairs_dt >= 0) & (pairs_dt < max_interval_s)
+    total_trials = valid_trials.size
+    valid_count = int(valid_trials.sum())
+    valid_fraction = valid_count / total_trials if total_trials > 0 else np.nan
 
     if plot:
         cmap = cm.get_cmap(cmap_name)
@@ -980,8 +983,13 @@ def plot_eye_fixations_between_cue_and_go_by_trial(
         ax.set_aspect("equal")
         ax.set_xlabel("Eye center X (deg)")
         ax.set_ylabel("Eye center Y (deg)")
+        if total_trials > 0:
+            ratio_text = f"{valid_count}/{total_trials} ({valid_fraction * 100:.0f}%)"
+        else:
+            ratio_text = "0/0 (n/a)"
         ax.set_title(
-            f"Eye positions between cue and go (<{max_interval_s:.2f}s)"
+            "Eye positions between cue and go "
+            f"(<{max_interval_s:.2f}s)\nValid trials: {ratio_text}"
         )
 
         if results_dir is not None:


### PR DESCRIPTION
## Summary
- display valid vs total trial counts in cue→go fixation plots and guard zero-trial cases
- record total trial counts and fractions in per-session fixation summaries for downstream use
- propagate the new metrics through population aggregation and annotate trend plot titles with the mean valid-trial percentage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d067462318832585fdcd565053f437