### PR TITLE
Add cue-go interval plotting helper

### DIFF
--- a/Clean/Python/analysis/fixation_session.py
+++ b/Clean/Python/analysis/fixation_session.py
@@ -56,15 +56,23 @@ def main(session_id: str) -> pd.DataFrame:
         data=data,
         plot=False,
     )
-    plt.show()
     if fig_saccades is not None:
+        plt.show()
         plt.close(fig_saccades)
 
 
     max_interval_s = float(config.params.get("max_interval_s", 1.0))
 
-    ( pairs_cf,pairs_gf,pairs_ct,pairs_gt,
-        pairs_dt,valid_trials,fig_pairs,_,
+    (
+        pairs_cf,
+        pairs_gf,
+        pairs_ct,
+        pairs_gt,
+        pairs_dt,
+        valid_trials,
+        fig_pairs,
+        _,
+        fig_interval,
     ) = plot_eye_fixations_between_cue_and_go_by_trial(
         eye_frame=data.eye_frame,
         eye_pos=saccades["eye_pos"],
@@ -81,8 +89,9 @@ def main(session_id: str) -> pd.DataFrame:
         plot=True,
     )
     plt.show()
-    if fig_pairs is not None:
-        plt.close(fig_pairs)
+    for fig in (fig_pairs, fig_interval):
+        if fig is not None:
+            plt.close(fig)
 
     total_trials = int(valid_trials.size)
     valid_count = int(valid_trials.sum())

--- a/Clean/Python/eyehead/__init__.py
+++ b/Clean/Python/eyehead/__init__.py
@@ -7,6 +7,7 @@ from .analysis import (
     detect_saccades,
     organize_stims,
     sort_saccades,
+    plot_fixation_intervals_by_trial,
     plot_eye_fixations_between_cue_and_go_by_trial,
     quantify_fixation_stability_vs_random,
 )
@@ -34,6 +35,7 @@ __all__ = [
     "detect_saccades",
     "organize_stims",
     "sort_saccades",
+    "plot_fixation_intervals_by_trial",
     "plot_eye_fixations_between_cue_and_go_by_trial",
     "quantify_fixation_stability_vs_random",
     "butter_noncausal",


### PR DESCRIPTION
## Summary
- add a helper that visualises cue→go intervals per trial, saves annotated figures, and skips saving when no trials are available
- invoke the interval helper from the cue→go fixation plot while returning the new figure handle for callers
- close generated figures in the fixation session analysis flow and export the helper via the package namespace

## Testing
- pytest Clean/Python/tests

------
https://chatgpt.com/codex/tasks/task_e_68d0904de52c8325b7ba0a50c8188315