### PR TITLE
Group active stabilization plot by date, stack same-date sessions vertically

### DIFF
--- a/Python/analysis/fixation_population.py
+++ b/Python/analysis/fixation_population.py
@@ -290,10 +290,11 @@ def plot_active_stabilization(
     *,
     animal_name: str | None = None,
 ) -> None:
-    """Plot active_stabilization across sessions with session dates on each point.
+    """Plot active_stabilization across sessions grouped by recording date.
 
-    Sessions are sorted by recording date and plotted left-to-right on the
-    x-axis.  Each point is labelled with its session date.
+    Sessions recorded on the same date share an x-axis position and appear
+    vertically stacked at their respective metric values.  Each point is
+    labelled with its session date.
     """
     if df.empty or "active_stabilization" not in df.columns:
         return
@@ -302,23 +303,29 @@ def plot_active_stabilization(
     data["session_date"] = pd.to_datetime(data["session_date"], errors="coerce")
     data.sort_values("session_date", inplace=True, ignore_index=True)
 
-    metric = pd.to_numeric(data["active_stabilization"], errors="coerce")
-    order = np.arange(len(data))
+    # Assign each session an x position equal to the index of its unique date
+    unique_dates = data["session_date"].drop_duplicates().sort_values().reset_index(drop=True)
+    date_to_x = {d: i for i, d in enumerate(unique_dates)}
+    x_pos = data["session_date"].map(date_to_x).to_numpy(dtype=float)
 
-    fig, ax = plt.subplots(figsize=(max(6, len(data) * 0.9), 4))
+    metric = pd.to_numeric(data["active_stabilization"], errors="coerce").to_numpy()
 
-    ax.plot(order, metric, linestyle="--", color="0.7", linewidth=1, zorder=1)
-    ax.scatter(order, metric, color="steelblue", s=60, zorder=2)
+    n_dates = len(unique_dates)
+    fig, ax = plt.subplots(figsize=(max(6, n_dates * 1.1), 4))
 
-    for i in order:
-        y = metric.iloc[i]
+    # Connect points in chronological order with a dashed line
+    ax.plot(x_pos, metric, linestyle="--", color="0.75", linewidth=1, zorder=1)
+    ax.scatter(x_pos, metric, color="steelblue", s=60, zorder=2)
+
+    for i in range(len(data)):
+        y = metric[i]
         if not np.isfinite(y):
             continue
         date_val = data["session_date"].iloc[i]
         label = date_val.strftime("%Y-%m-%d") if pd.notna(date_val) else ""
         ax.annotate(
             label,
-            xy=(i, y),
+            xy=(x_pos[i], y),
             xytext=(0, 8),
             textcoords="offset points",
             ha="center",
@@ -329,9 +336,14 @@ def plot_active_stabilization(
         )
 
     ax.axhline(0, color="0.4", linestyle=":", linewidth=0.8)
-    ax.set_xticks(order)
-    ax.set_xticklabels([""] * len(order))
-    ax.set_xlabel("Session (earlier → later)")
+    ax.set_xticks(np.arange(n_dates))
+    ax.set_xticklabels(
+        [d.strftime("%Y-%m-%d") if pd.notna(d) else "" for d in unique_dates],
+        rotation=45,
+        ha="right",
+        fontsize=8,
+    )
+    ax.set_xlabel("Session date")
     ax.set_ylabel("Active stabilization\n(cue_suppression × selection_bias²)")
     title = "Active stabilization across sessions"
     if animal_name:


### PR DESCRIPTION
## Summary

- Sessions recorded on the same date now share an x-axis position and appear vertically stacked at their respective `active_stabilization` values
- X-tick labels show the date (rotated 45°) for a readable axis
- Each point is still individually annotated with its session date
- Dashed line connects points in chronological order

## Test plan

- [ ] Run `python Python/analysis/fixation_population.py --animal-name Paris` and verify same-date sessions stack at the same x position
- [ ] Confirm x-tick labels show dates and points are annotated with dates
- [ ] Confirm PNG and SVG save correctly

https://claude.ai/code/session_01CXFo7tmcMV3PaSrkju9nVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXFo7tmcMV3PaSrkju9nVX)_