### PR TITLE
Refactor animal name formatting from suffix to prefix pattern

### DIFF
--- a/Python/analysis/fixation_population.py
+++ b/Python/analysis/fixation_population.py
@@ -27,15 +27,15 @@ from utils.session_loader import list_sessions_from_manifest, load_session
 assert main is fixation_session.main
 
 
-def _animal_suffix(animal_name: str | None) -> str:
-    """Return a filesystem-friendly suffix for ``animal_name``."""
+def _animal_prefix(animal_name: str | None) -> str:
+    """Return a filesystem-friendly prefix for ``animal_name``."""
 
     if not animal_name:
         return ""
 
     safe_name = re.sub(r"[^0-9A-Za-z_-]+", "_", animal_name.strip())
     safe_name = safe_name.strip("_")
-    return f"_{safe_name}" if safe_name else ""
+    return f"{safe_name}_" if safe_name else ""
 
 
 def analyze_all_sessions(
@@ -161,7 +161,7 @@ def plot_metric_trends(
         ),
     ]
 
-    suffix = _animal_suffix(animal_name)
+    prefix = _animal_prefix(animal_name)
 
     for fix_col, fix_sem_col, rand_col, rand_sem_col, ylabel, fname in metrics:
         if fix_col not in data or rand_col not in data:
@@ -280,7 +280,7 @@ def plot_metric_trends(
         ax.legend()
 
         fig.tight_layout()
-        fig.savefig(save_dir / f"{fname}{suffix}.png", bbox_inches="tight")
+        fig.savefig(save_dir / f"{prefix}{fname}.png", bbox_inches="tight")
         plt.close(fig)
 
 
@@ -351,9 +351,9 @@ def plot_active_stabilization(
     ax.set_title(title)
 
     fig.tight_layout()
-    suffix = _animal_suffix(animal_name)
+    prefix = _animal_prefix(animal_name)
     for ext in ("png", "svg"):
-        fig.savefig(save_dir / f"active_stabilization_trend{suffix}.{ext}", bbox_inches="tight")
+        fig.savefig(save_dir / f"{prefix}active_stabilization_trend.{ext}", bbox_inches="tight")
     plt.show()
     plt.close(fig)
 
@@ -391,9 +391,9 @@ if __name__ == "__main__":
         max_interval_fixations = None
     results_root = Path(manifest.get("results_root", root_dir))
     results_root.mkdir(parents=True, exist_ok=True)
-    suffix = _animal_suffix(args.animal_name)
+    prefix = _animal_prefix(args.animal_name)
     #aggregated.to_csv(
-        #results_root / f"fixation_population_results{suffix}.csv", index=False
+        #results_root / f"{prefix}fixation_population_results.csv", index=False
     #)
     plot_metric_trends(
         aggregated,


### PR DESCRIPTION
## Summary
Refactored the animal name formatting logic to use a prefix pattern instead of a suffix pattern for generated filenames. This change improves filename readability by placing the animal identifier at the beginning of filenames rather than at the end.

## Key Changes
- Renamed `_animal_suffix()` function to `_animal_prefix()` to better reflect its new behavior
- Changed the formatting from `f"_{safe_name}"` (suffix) to `f"{safe_name}_"` (prefix)
- Updated all filename generation calls to use the new prefix pattern:
  - `f"{fname}{suffix}.png"` → `f"{prefix}{fname}.png"`
  - `f"active_stabilization_trend{suffix}.{ext}"` → `f"{prefix}active_stabilization_trend.{ext}"`
  - `f"fixation_population_results{suffix}.csv"` → `f"{prefix}fixation_population_results.csv"`
- Updated all variable names from `suffix` to `prefix` throughout the codebase for consistency

## Implementation Details
The function still handles the same input validation and sanitization logic (removing special characters and stripping underscores), but now returns the formatted name with a trailing underscore instead of a leading one. This results in filenames like `animal_name_metric.png` instead of `metric_animal_name.png`, which is more conventional for file organization and sorting.

https://claude.ai/code/session_013didPY15sUCE1m27SYC8i9