### PR TITLE
Fix fixation_population including fixation_feedback sessions

### DIFF
--- a/Python/analysis/fixation_population.py
+++ b/Python/analysis/fixation_population.py
@@ -59,7 +59,7 @@ def analyze_all_sessions(
     """
     tables: list[pd.DataFrame] = []
     for session_id in list_sessions_from_manifest(
-        experiment_type, match_prefix=True, animal_name=animal_name
+        experiment_type, match_prefix=False, animal_name=animal_name
     ):
         session_df = fixation_session.main(session_id)
 

--- a/Python/analysis/fixation_session.py
+++ b/Python/analysis/fixation_session.py
@@ -278,7 +278,10 @@ def plot_pericue_pre_post_summary(
             transform=ax.get_xaxis_transform(), fontsize=11, fontweight="bold",
             color="#c0392b")
 
-    y_max = max(m + s for m, s in zip(means, sems) if not np.isnan(m + s))
+    finite_vals = [m + s for m, s in zip(means, sems) if not np.isnan(m + s)]
+    if not finite_vals:
+        return fig, {}
+    y_max = max(finite_vals)
     gap = y_max * 0.08
 
     def _bracket(x1, x2, y, label):


### PR DESCRIPTION
## Summary

- **`fixation_population.py`**: Change `match_prefix=True` → `match_prefix=False` in `analyze_all_sessions` so that `experiment_type="fixation"` matches exactly, not as a prefix that also catches `fixation_feedback` sessions
- **`fixation_session.py`**: Guard `plot_pericue_pre_post_summary` against all-NaN means/SEMs — return the partial figure early instead of crashing on `max()` of an empty sequence (`ValueError: max() arg is an empty sequence`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013didPY15sUCE1m27SYC8i9)_