### PR TITLE
Add animal_id to session data and use it for file naming

### DIFF
--- a/Python/analysis/fixation_population.py
+++ b/Python/analysis/fixation_population.py
@@ -351,7 +351,8 @@ def plot_active_stabilization(
     ax.set_title(title)
 
     fig.tight_layout()
-    prefix = _animal_prefix(animal_name)
+    animal_id = data["animal_id"].dropna().iloc[0] if "animal_id" in data.columns and not data["animal_id"].dropna().empty else animal_name
+    prefix = _animal_prefix(animal_id)
     for ext in ("png", "svg"):
         fig.savefig(save_dir / f"{prefix}active_stabilization_trend.{ext}", bbox_inches="tight")
     plt.show()

--- a/Python/analysis/fixation_session.py
+++ b/Python/analysis/fixation_session.py
@@ -446,6 +446,7 @@ def main(session_id: str) -> pd.DataFrame:
     df = pd.DataFrame(
         {
             "session_id": [session_id],
+            "animal_id": [config.animal_id],
             "animal_name": [config.animal_name],
             "session_date": [date_str],
             "valid_trials": [valid_count],


### PR DESCRIPTION
## Summary
This PR adds `animal_id` to the session analysis output and updates the file naming logic to prefer `animal_id` over `animal_name` when available.

## Key Changes
- **fixation_session.py**: Added `animal_id` field to the DataFrame output in the `main()` function, capturing the animal ID from the session configuration
- **fixation_population.py**: Updated `plot_active_stabilization()` to extract `animal_id` from the data when available and use it for generating output filenames, falling back to `animal_name` if `animal_id` is not present

## Implementation Details
The `animal_id` extraction in `plot_active_stabilization()` includes a safety check to handle cases where the column may not exist or contain only null values, ensuring backward compatibility with data that doesn't include `animal_id`.

https://claude.ai/code/session_013didPY15sUCE1m27SYC8i9