### PR TITLE
Fix y-axis on active stabilization plot and restore --experiment-type flag

### DIFF
--- a/Python/analysis/fixation_population.py
+++ b/Python/analysis/fixation_population.py
@@ -153,6 +153,7 @@ def plot_active_stabilization(
         #     )
 
     ax.axhline(0, color="0.4", linestyle=":", linewidth=0.8)
+    ax.set_ylim(0, 1)
     ax.set_xticks(np.arange(max_sessions))
     ax.set_xticklabels(np.arange(1, max_sessions + 1), fontsize=8)
     ax.set_xlabel("Session number")

--- a/Python/analysis/fixation_population.py
+++ b/Python/analysis/fixation_population.py
@@ -154,7 +154,6 @@ def plot_active_stabilization(
 
     ax.axhline(0, color="0.4", linestyle=":", linewidth=0.8)
     ax.set_xticks(np.arange(max_sessions))
-    ax.set_yticks([0,0.5,1.0]);
     ax.set_xticklabels(np.arange(1, max_sessions + 1), fontsize=8)
     ax.set_xlabel("Session number")
     ax.set_ylabel("Active stabilization\n(cue_suppression × selection_bias²)")
@@ -189,6 +188,13 @@ if __name__ == "__main__":
         help="One or more animal names to include (e.g. --animal-name Paris Apollo)",
     )
     parser.add_argument(
+        "--experiment-type",
+        nargs="+",
+        default=None,
+        choices=["fixation", "fixation_learning"],
+        help="Which experiment type(s) to process (default: both)",
+    )
+    parser.add_argument(
         "--show-session-plots",
         action="store_true",
         default=False,
@@ -209,17 +215,19 @@ if __name__ == "__main__":
     animal_names = args.animal_name or [None]
     title_name = " & ".join(animal_names) if animal_names != [None] else None
 
-    experiment_configs = [
-        (
-            "fixation",
+    all_experiment_configs = {
+        "fixation": (
             "fixation_trend",
             "Fixation without visual feedback across sessions",
         ),
-        (
-            "fixation_learning",
+        "fixation_learning": (
             "fixation_learning_trend",
             "Fixation learning across sessions",
         ),
+    }
+    requested = args.experiment_type or list(all_experiment_configs.keys())
+    experiment_configs = [
+        (exp_type, *all_experiment_configs[exp_type]) for exp_type in requested
     ]
 
     for exp_type, fname_stem, plot_title in experiment_configs:


### PR DESCRIPTION
## Summary

- Removed hardcoded `set_yticks([0, 0.5, 1.0])` and replaced with `set_ylim(0, 1)` — fixes clipped y-axis for `fixation_learning` sessions
- Restores `--experiment-type` flag (was lost when main diverged from PR #178), allowing `--experiment-type fixation_learning` to run only learning sessions

## Test plan

- [ ] `python Python/analysis/fixation_population.py --animal-name Bayleaf --experiment-type fixation_learning` — y-axis shows 0–1, plot saves correctly
- [ ] `python Python/analysis/fixation_population.py --animal-name Paris` — both experiment types run, y-axis 0–1 on both plots

https://claude.ai/code/session_013didPY15sUCE1m27SYC8i9

---
_Generated by [Claude Code](https://claude.ai/code/session_013didPY15sUCE1m27SYC8i9)_