### PR TITLE
Add average successful trial time plots (session + population)

### DIFF
--- a/Python/analysis/fixationfeedback_population.py
+++ b/Python/analysis/fixationfeedback_population.py
@@ -31,7 +31,7 @@ import yaml
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from utils.session_loader import list_sessions_from_manifest, load_session
-from fixationfeedback_session import load_fixation_feedback_data
+from fixationfeedback_session import load_fixation_feedback_data, compute_success_trial_times
 from fixation_session import bonsai_to_deg
 
 
@@ -201,6 +201,64 @@ def plot_population_psychometric(
 
 
 # ---------------------------------------------------------------------------
+# Trial time trend plot (population)
+# ---------------------------------------------------------------------------
+
+_ANIMAL_COLORS = ["navy", "darkorange", "darkgreen", "indigo", "darkred", "saddlebrown"]
+
+
+def plot_trial_time_trend(
+    all_session_records: list[dict],
+    animal_ids: list[str],
+    animal_names: list[str],
+    results_dir: Optional[Path] = None,
+    show_plots: bool = True,
+) -> None:
+    """Scatter/line plot of mean successful trial time across sessions, one per animal."""
+    fig, ax = plt.subplots(figsize=(max(6, len(all_session_records) * 1.1), 4))
+
+    for a_idx, animal_name in enumerate(animal_names):
+        recs = [r for r in all_session_records if r.get("animal_name") == animal_name]
+        if not recs:
+            continue
+
+        color = _ANIMAL_COLORS[a_idx % len(_ANIMAL_COLORS)]
+        times = np.array([r["avg_success_trial_time"] for r in recs], dtype=float)
+        x_pos = np.arange(len(recs))
+        label = animal_name if len(animal_names) > 1 else None
+
+        ax.plot(x_pos, times, linestyle="--", color=color, linewidth=1, alpha=0.7, zorder=1)
+        ax.scatter(x_pos, times, color=color, s=60, zorder=2, label=label)
+
+        ax.set_xticks(x_pos)
+        ax.set_xticklabels(np.arange(1, len(recs) + 1), fontsize=8)
+
+    ax.set_xlabel("Session number")
+    ax.set_ylabel("Avg successful trial time (s)")
+    title = "Fixation w Visual Feedback: successful trial time across sessions"
+    label_parts = [p for p in animal_names if p]
+    if label_parts:
+        title += f"\n{' & '.join(label_parts)}"
+    ax.set_title(title)
+    if len(animal_names) > 1:
+        ax.legend(loc="best", fontsize=9)
+
+    fig.tight_layout()
+
+    if results_dir is not None:
+        results_dir.mkdir(parents=True, exist_ok=True)
+        prefix = "_".join(aid for aid in animal_ids if aid)
+        if prefix:
+            prefix += "_"
+        for ext in ("png", "svg"):
+            fig.savefig(results_dir / f"{prefix}trial_time_trend.{ext}", bbox_inches="tight")
+
+    if show_plots:
+        plt.show()
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
 # Data loading helper (per animal)
 # ---------------------------------------------------------------------------
 
@@ -250,6 +308,9 @@ def _load_animal_sessions(
 
         psychometric = compute_session_psychometric(eot_df, target_df)
 
+        success_times = compute_success_trial_times(eot_df, target_df)
+        avg_trial_time = float(np.nanmean(success_times)) if len(success_times) > 0 else float("nan")
+
         folder_name = config.folder_path.name
         date_match = re.search(r"\d{4}-\d{2}-\d{2}", folder_name)
         date_str = date_match.group() if date_match else ""
@@ -260,6 +321,7 @@ def _load_animal_sessions(
             "animal_name": animal_name,
             "animal_id": animal_id,
             "psychometric": psychometric,
+            "avg_success_trial_time": avg_trial_time,
         })
 
         n_trials = len(eot_df)
@@ -272,6 +334,7 @@ def _load_animal_sessions(
             "n_trials": [n_trials],
             "n_success": [n_success],
             "success_rate": [n_success / n_trials if n_trials > 0 else float("nan")],
+            "avg_success_trial_time": [avg_trial_time],
         }))
 
     session_records.sort(key=lambda r: r["date"])
@@ -295,6 +358,13 @@ def analyze_animal(
         return pd.DataFrame()
 
     plot_population_psychometric(
+        session_records,
+        animal_ids=[animal_id],
+        animal_names=[animal_name],
+        results_dir=results_dir,
+        show_plots=show_plots,
+    )
+    plot_trial_time_trend(
         session_records,
         animal_ids=[animal_id],
         animal_names=[animal_name],
@@ -326,6 +396,13 @@ def analyze_animals(
         return pd.DataFrame()
 
     plot_population_psychometric(
+        all_records,
+        animal_ids=animal_ids,
+        animal_names=animal_names,
+        results_dir=results_dir,
+        show_plots=show_plots,
+    )
+    plot_trial_time_trend(
         all_records,
         animal_ids=animal_ids,
         animal_names=animal_names,

--- a/Python/analysis/fixationfeedback_session.py
+++ b/Python/analysis/fixationfeedback_session.py
@@ -100,6 +100,73 @@ def load_fixation_feedback_data(folder_path: Path) -> Tuple[pd.DataFrame, pd.Dat
     return eot_df, target_df
 
 
+def compute_success_trial_times(
+    eot_df: pd.DataFrame,
+    target_df: pd.DataFrame,
+) -> np.ndarray:
+    """Return trial durations (s) for successful trials (trial_success == 2).
+
+    Uses eot_df.timestamp - target_df.timestamp when target_df has timestamps
+    (cue onset → trial end).  Returns an empty array when timestamps are
+    unavailable or no successful trials exist.
+    """
+    if "trial_success" not in eot_df.columns:
+        return np.array([])
+
+    success_mask = eot_df["trial_success"].values == 2
+    n = min(len(eot_df), len(target_df))
+
+    eot_ts = pd.to_numeric(eot_df["timestamp"], errors="coerce").to_numpy()
+
+    if "timestamp" in target_df.columns:
+        tgt_ts = pd.to_numeric(target_df["timestamp"], errors="coerce").to_numpy()
+        durations = (eot_ts[:n] - tgt_ts[:n])
+    else:
+        return np.array([])
+
+    return durations[success_mask[:n]]
+
+
+def plot_trial_time_session(
+    eot_df: pd.DataFrame,
+    target_df: pd.DataFrame,
+    results_dir: Path,
+    animal_id: str = "",
+    date_str: str = "",
+    show_plots: bool = True,
+) -> Optional[plt.Figure]:
+    """Histogram of successful-trial durations for one session."""
+    times = compute_success_trial_times(eot_df, target_df)
+    if len(times) == 0:
+        return None
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.hist(times, bins=20, color="steelblue", edgecolor="white", alpha=0.8)
+    mean_t = float(np.nanmean(times))
+    ax.axvline(mean_t, color="red", linestyle="--", linewidth=1.5,
+               label=f"Mean = {mean_t:.2f} s")
+    ax.set_xlabel("Trial time (s)")
+    ax.set_ylabel("Count")
+    title = "Successful trial durations"
+    if animal_id:
+        title += f" – {animal_id}"
+    if date_str:
+        title += f" ({date_str})"
+    ax.set_title(title)
+    ax.legend()
+    fig.tight_layout()
+
+    prefix = f"{animal_id}_" if animal_id else ""
+    date_tag = f"_{date_str}" if date_str else ""
+    for ext in ("png", "svg"):
+        fig.savefig(results_dir / f"{prefix}trial_time{date_tag}.{ext}", bbox_inches="tight")
+
+    if show_plots:
+        plt.show()
+    plt.close(fig)
+    return fig
+
+
 def analyze_session(
     folder_path: str | Path,
     results_dir: Optional[str | Path] = None,
@@ -151,8 +218,15 @@ def analyze_session(
             plt.show()
         plt.close(fig)
 
+    print("\nGenerating trial time plot...")
+    plot_trial_time_session(eot_df, target_df, results_dir, animal_id, date_str,
+                            show_plots=show_plots)
+
     n_trials = len(eot_df)
     n_success = int((eot_df["trial_success"] == 2).sum()) if "trial_success" in eot_df.columns else 0
+
+    success_times = compute_success_trial_times(eot_df, target_df)
+    avg_success_trial_time = float(np.nanmean(success_times)) if len(success_times) > 0 else float("nan")
 
     return pd.DataFrame({
         "session_id": [folder_name],
@@ -162,6 +236,7 @@ def analyze_session(
         "n_trials": [n_trials],
         "n_success": [n_success],
         "success_rate": [n_success / n_trials if n_trials > 0 else float("nan")],
+        "avg_success_trial_time": [avg_success_trial_time],
     })
 
 


### PR DESCRIPTION
## Summary

- Adds `compute_success_trial_times()` to `fixationfeedback_session.py` — computes per-trial duration as `eot_df.timestamp - target_df.timestamp` for trials where `trial_success == 2`
- Adds `plot_trial_time_session()` — histogram of successful trial durations with mean marked, saved per session as `<animal>_trial_time_<date>.{png,svg}`
- `analyze_session()` now calls both helpers and returns `avg_success_trial_time` in its summary DataFrame
- `_load_animal_sessions()` in `fixationfeedback_population.py` computes and stores `avg_success_trial_time` per session
- Adds `plot_trial_time_trend()` — scatter/line trend across sessions (consistent style with other population trend plots), saved as `<prefix>trial_time_trend.{png,svg}`
- Trend plot is called automatically from both `analyze_animal()` and `analyze_animals()`

Also includes the valid% trend plot for `fixation_population.py` from the previous commit.

## Test plan

- [ ] Run `fixationfeedback_session.py` on a single session and confirm a trial time histogram is saved alongside the psychometric curve
- [ ] Confirm `avg_success_trial_time` appears in the returned DataFrame
- [ ] Run `fixationfeedback_population.py --animal-name <name>` and confirm `<prefix>trial_time_trend.{png,svg}` is saved
- [ ] Check that sessions where `target_df` has no timestamp column skip gracefully (no crash, NaN in summary)
- [ ] Verify multi-animal case produces per-animal colors and a legend in the trend plot

https://claude.ai/code/session_01MR9uSVUfvjLAwrYUp6Nn6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01MR9uSVUfvjLAwrYUp6Nn6s)_