### PR TITLE
Add trial time plots by target diameter (session + population)

### DIFF
--- a/Python/analysis/fixationfeedback_population.py
+++ b/Python/analysis/fixationfeedback_population.py
@@ -31,7 +31,11 @@ import yaml
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from utils.session_loader import list_sessions_from_manifest, load_session
-from fixationfeedback_session import load_fixation_feedback_data, compute_success_trial_times
+from fixationfeedback_session import (
+    load_fixation_feedback_data,
+    compute_success_trial_times,
+    compute_trial_times_by_diameter,
+)
 from fixation_session import bonsai_to_deg
 
 
@@ -258,6 +262,95 @@ def plot_trial_time_trend(
     plt.close(fig)
 
 
+def plot_trial_time_by_diameter_population(
+    all_session_records: list[dict],
+    animal_ids: list[str],
+    animal_names: list[str],
+    results_dir: Optional[Path] = None,
+    show_plots: bool = True,
+) -> None:
+    """Population mean ± SD of successful trial time vs target diameter, per animal.
+
+    Mirrors the layout of plot_population_psychometric.
+    """
+    all_diameters: set[float] = set()
+    for rec in all_session_records:
+        all_diameters.update(rec.get("trial_times_by_diameter", {}).keys())
+    diameters = np.array(sorted(all_diameters))
+
+    if len(diameters) == 0:
+        print("Warning: no trial-time-by-diameter data found — skipping population plot")
+        return
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    for a_idx, animal_name in enumerate(animal_names):
+        cmap_name = _ANIMAL_CMAPS[a_idx % len(_ANIMAL_CMAPS)]
+        mean_color = _ANIMAL_MEAN_COLORS[a_idx % len(_ANIMAL_MEAN_COLORS)]
+
+        session_recs = [r for r in all_session_records if r.get("animal_name") == animal_name]
+        n_sessions = len(session_recs)
+        if n_sessions == 0:
+            continue
+
+        time_matrix = np.full((n_sessions, len(diameters)), np.nan)
+        for s_idx, rec in enumerate(session_recs):
+            for d_idx, d in enumerate(diameters):
+                entry = rec.get("trial_times_by_diameter", {}).get(d)
+                if entry is not None:
+                    time_matrix[s_idx, d_idx] = entry[0]
+
+        with np.errstate(all="ignore"):
+            pop_mean = np.nanmean(time_matrix, axis=0)
+            pop_n = np.sum(~np.isnan(time_matrix), axis=0)
+            pop_sd = np.nanstd(time_matrix, axis=0, ddof=1)
+
+        valid_pop = ~np.isnan(pop_mean)
+        animal_label = animal_name or (animal_ids[a_idx] if a_idx < len(animal_ids) else "")
+        ax.errorbar(
+            diameters[valid_pop], pop_mean[valid_pop], yerr=pop_sd[valid_pop],
+            fmt="o-", color=mean_color, ecolor=mean_color,
+            markersize=10, linewidth=2.5, capsize=5, capthick=2,
+            label=f"{animal_label} mean ± SD", zorder=5,
+        )
+
+        for d, mean_val, sd_val, n in zip(
+            diameters[valid_pop], pop_mean[valid_pop], pop_sd[valid_pop], pop_n[valid_pop]
+        ):
+            ax.text(d, mean_val + sd_val + 0.05, f"n={int(n)}",
+                    ha="center", va="bottom", fontsize=9,
+                    fontweight="bold", color=mean_color)
+
+    ax.set_xlabel("Target Diameter (°)", fontsize=14, fontweight="bold")
+    ax.set_ylabel("Mean successful trial time (s)", fontsize=14, fontweight="bold")
+
+    title = "Fixation w Visual Feedback: Trial Time vs Target Diameter"
+    label_parts = [p for p in animal_names if p]
+    if label_parts:
+        title += f"\n{' & '.join(label_parts)}"
+    ax.set_title(title, fontsize=14, fontweight="bold")
+
+    x_pad = (diameters.max() - diameters.min()) * 0.08 if len(diameters) > 1 else 0.1
+    ax.set_xlim(diameters.min() - x_pad, diameters.max() + x_pad)
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="best", fontsize=9, framealpha=0.7)
+
+    plt.tight_layout()
+
+    if results_dir is not None:
+        results_dir.mkdir(parents=True, exist_ok=True)
+        prefix = "_".join(aid for aid in animal_ids if aid)
+        if prefix:
+            prefix += "_"
+        for ext in ("png", "svg"):
+            fig.savefig(results_dir / f"{prefix}trial_time_by_diameter_population.{ext}",
+                        bbox_inches="tight")
+
+    if show_plots:
+        plt.show()
+    plt.close(fig)
+
+
 # ---------------------------------------------------------------------------
 # Data loading helper (per animal)
 # ---------------------------------------------------------------------------
@@ -310,6 +403,7 @@ def _load_animal_sessions(
 
         success_times = compute_success_trial_times(eot_df, target_df)
         avg_trial_time = float(np.nanmean(success_times)) if len(success_times) > 0 else float("nan")
+        trial_times_by_diam = compute_trial_times_by_diameter(eot_df, target_df)
 
         folder_name = config.folder_path.name
         date_match = re.search(r"\d{4}-\d{2}-\d{2}", folder_name)
@@ -322,6 +416,7 @@ def _load_animal_sessions(
             "animal_id": animal_id,
             "psychometric": psychometric,
             "avg_success_trial_time": avg_trial_time,
+            "trial_times_by_diameter": trial_times_by_diam,
         })
 
         n_trials = len(eot_df)
@@ -371,6 +466,13 @@ def analyze_animal(
         results_dir=results_dir,
         show_plots=show_plots,
     )
+    plot_trial_time_by_diameter_population(
+        session_records,
+        animal_ids=[animal_id],
+        animal_names=[animal_name],
+        results_dir=results_dir,
+        show_plots=show_plots,
+    )
 
     return pd.concat(summary_rows, ignore_index=True) if summary_rows else pd.DataFrame()
 
@@ -403,6 +505,13 @@ def analyze_animals(
         show_plots=show_plots,
     )
     plot_trial_time_trend(
+        all_records,
+        animal_ids=animal_ids,
+        animal_names=animal_names,
+        results_dir=results_dir,
+        show_plots=show_plots,
+    )
+    plot_trial_time_by_diameter_population(
         all_records,
         animal_ids=animal_ids,
         animal_names=animal_names,

--- a/Python/analysis/fixationfeedback_session.py
+++ b/Python/analysis/fixationfeedback_session.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from utils.session_loader import load_session
 from eyehead.io import clean_csv
-from fixation_session import plot_psychometric_central_fixation
+from fixation_session import plot_psychometric_central_fixation, bonsai_to_deg
 
 
 def load_fixation_feedback_data(folder_path: Path) -> Tuple[pd.DataFrame, pd.DataFrame]:
@@ -127,6 +127,47 @@ def compute_success_trial_times(
     return durations[success_mask[:n]]
 
 
+def compute_trial_times_by_diameter(
+    eot_df: pd.DataFrame,
+    target_df: pd.DataFrame,
+) -> dict[float, tuple[float, float, int]]:
+    """Return {diameter_deg: (mean_s, sd_s, n)} for successful trials grouped by diameter.
+
+    Returns empty dict when timestamps or diameter data are unavailable.
+    """
+    if (
+        "trial_success" not in eot_df.columns
+        or "timestamp" not in target_df.columns
+        or "diameter" not in target_df.columns
+    ):
+        return {}
+
+    n = min(len(eot_df), len(target_df))
+    eot_ts = pd.to_numeric(eot_df["timestamp"], errors="coerce").to_numpy()
+    tgt_ts = pd.to_numeric(target_df["timestamp"], errors="coerce").to_numpy()
+    durations = eot_ts[:n] - tgt_ts[:n]
+
+    combined = pd.DataFrame({
+        "trial_success": eot_df["trial_success"].iloc[:n].values,
+        "diameter": target_df["diameter"].iloc[:n].values,
+        "duration": durations,
+    })
+    success = combined[combined["trial_success"] == 2]
+
+    result: dict[float, tuple[float, float, int]] = {}
+    for diam, group in success.groupby("diameter"):
+        diam_key = round(float(bonsai_to_deg(diam)), 3)
+        times = group["duration"].dropna().values
+        if len(times) == 0:
+            continue
+        result[diam_key] = (
+            float(np.mean(times)),
+            float(np.std(times, ddof=1)) if len(times) > 1 else 0.0,
+            len(times),
+        )
+    return result
+
+
 def plot_trial_time_session(
     eot_df: pd.DataFrame,
     target_df: pd.DataFrame,
@@ -135,31 +176,35 @@ def plot_trial_time_session(
     date_str: str = "",
     show_plots: bool = True,
 ) -> Optional[plt.Figure]:
-    """Histogram of successful-trial durations for one session."""
-    times = compute_success_trial_times(eot_df, target_df)
-    if len(times) == 0:
+    """Bar chart of mean successful trial time per target diameter for one session."""
+    times_by_diam = compute_trial_times_by_diameter(eot_df, target_df)
+    if not times_by_diam:
         return None
 
-    fig, ax = plt.subplots(figsize=(6, 4))
-    ax.hist(times, bins=20, color="steelblue", edgecolor="white", alpha=0.8)
-    mean_t = float(np.nanmean(times))
-    ax.axvline(mean_t, color="red", linestyle="--", linewidth=1.5,
-               label=f"Mean = {mean_t:.2f} s")
-    ax.set_xlabel("Trial time (s)")
-    ax.set_ylabel("Count")
-    title = "Successful trial durations"
+    diameters = sorted(times_by_diam.keys())
+    means = [times_by_diam[d][0] for d in diameters]
+    sds = [times_by_diam[d][1] for d in diameters]
+    ns = [times_by_diam[d][2] for d in diameters]
+
+    fig, ax = plt.subplots(figsize=(max(5, len(diameters) * 1.2), 4))
+    ax.bar(range(len(diameters)), means, yerr=sds, color="steelblue",
+           edgecolor="white", alpha=0.8, capsize=4)
+    ax.set_xticks(range(len(diameters)))
+    ax.set_xticklabels([f"{d:.1f}°\n(n={n})" for d, n in zip(diameters, ns)], fontsize=9)
+    ax.set_xlabel("Target diameter (°)")
+    ax.set_ylabel("Mean trial time (s)")
+    title = "Successful trial time by target diameter"
     if animal_id:
         title += f" – {animal_id}"
     if date_str:
         title += f" ({date_str})"
     ax.set_title(title)
-    ax.legend()
     fig.tight_layout()
 
     prefix = f"{animal_id}_" if animal_id else ""
     date_tag = f"_{date_str}" if date_str else ""
     for ext in ("png", "svg"):
-        fig.savefig(results_dir / f"{prefix}trial_time{date_tag}.{ext}", bbox_inches="tight")
+        fig.savefig(results_dir / f"{prefix}trial_time_by_diameter{date_tag}.{ext}", bbox_inches="tight")
 
     if show_plots:
         plt.show()


### PR DESCRIPTION
## Summary

- Adds `compute_trial_times_by_diameter()` in `fixationfeedback_session.py` — groups successful trial durations (`eot_ts - target_ts`) by target diameter (converted to degrees), returning `{diameter_deg: (mean_s, sd_s, n)}`
- Replaces the flat histogram in `plot_trial_time_session()` with a bar chart of mean ± SD per target diameter, saved as `<prefix>trial_time_by_diameter<date>.{png,svg}`
- In `fixationfeedback_population.py`, stores per-diameter trial time data in each session record
- Adds `plot_trial_time_by_diameter_population()` — population mean ± SD errorbar curve vs target diameter, mirroring the layout of the psychometric curve plot, saved as `<prefix>trial_time_by_diameter_population.{png,svg}`
- Both `analyze_animal()` and `analyze_animals()` now produce the population plot automatically

## Test plan

- [ ] Run `fixationfeedback_session.py` on a single session and confirm a per-diameter bar chart is saved
- [ ] Confirm x-axis labels show diameter in degrees with trial count
- [ ] Run `fixationfeedback_population.py --animal-name <name>` and confirm `<prefix>trial_time_by_diameter_population.{png,svg}` is saved
- [ ] Check that sessions where `target_df` has no timestamp column skip gracefully
- [ ] Verify multi-animal case produces per-animal colors and a legend

https://claude.ai/code/session_01MR9uSVUfvjLAwrYUp6Nn6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01MR9uSVUfvjLAwrYUp6Nn6s)_