### PR TITLE
Add success trial time computation and session-level plotting

### DIFF
--- a/Python/analysis/fixationfeedback_population.py
+++ b/Python/analysis/fixationfeedback_population.py
@@ -406,13 +406,6 @@ def analyze_animal(
         results_dir=results_dir,
         show_plots=show_plots,
     )
-    plot_trial_time_trend(
-        session_records,
-        animal_ids=[animal_id],
-        animal_names=[animal_name],
-        results_dir=results_dir,
-        show_plots=show_plots,
-    )
     plot_trial_time_by_diameter_population(
         session_records,
         animal_ids=[animal_id],

--- a/Python/analysis/fixationfeedback_session.py
+++ b/Python/analysis/fixationfeedback_session.py
@@ -101,6 +101,30 @@ def load_fixation_feedback_data(folder_path: Path) -> Tuple[pd.DataFrame, pd.Dat
 
 
 
+def compute_success_trial_times(
+    eot_df: pd.DataFrame,
+    target_df: pd.DataFrame,
+) -> np.ndarray:
+    """Return array of trial durations (s) for successful trials only.
+
+    Returns empty array when required columns are unavailable.
+    """
+    if (
+        "trial_success" not in eot_df.columns
+        or "timestamp" not in eot_df.columns
+        or "timestamp" not in target_df.columns
+    ):
+        return np.array([], dtype=float)
+
+    n = min(len(eot_df), len(target_df))
+    eot_ts = pd.to_numeric(eot_df["timestamp"], errors="coerce").to_numpy()
+    tgt_ts = pd.to_numeric(target_df["timestamp"], errors="coerce").to_numpy()
+    durations = eot_ts[:n] - tgt_ts[:n]
+
+    success_mask = eot_df["trial_success"].iloc[:n].values == 2
+    return durations[success_mask & ~np.isnan(durations)]
+
+
 def compute_trial_times_by_diameter(
     eot_df: pd.DataFrame,
     target_df: pd.DataFrame,
@@ -111,6 +135,7 @@ def compute_trial_times_by_diameter(
     """
     if (
         "trial_success" not in eot_df.columns
+        or "timestamp" not in eot_df.columns
         or "timestamp" not in target_df.columns
         or "diameter" not in target_df.columns
     ):
@@ -237,7 +262,10 @@ def analyze_session(
             plt.show()
         plt.close(fig)
 
-
+    print("\nGenerating trial time by diameter plot...")
+    plot_trial_time_session(
+        eot_df, target_df, results_dir, animal_id, date_str, show_plots=show_plots
+    )
 
     return pd.DataFrame({
         "session_id": [folder_name],


### PR DESCRIPTION
## Summary
This PR adds a new function to compute trial durations for successful trials only and integrates session-level trial time plotting into the analysis workflow.

## Key Changes
- **New function `compute_success_trial_times()`**: Computes trial durations (in seconds) for successful trials only, with proper handling of missing columns and NaN values. Returns an empty array when required data is unavailable.
- **Enhanced validation in `compute_trial_times_by_diameter()`**: Added check for "timestamp" column in `eot_df` to prevent potential errors during analysis.
- **Session-level plotting integration**: Added call to `plot_trial_time_session()` in the `analyze_session()` function to generate trial time by diameter plots at the session level.
- **Removed redundant population-level plotting**: Removed `plot_trial_time_trend()` call from `analyze_animal()` in the population analysis module to avoid duplicate or unnecessary plotting.

## Implementation Details
- The new `compute_success_trial_times()` function filters trials where `trial_success == 2` and excludes NaN durations
- Trial durations are calculated as the difference between end-of-trial and target timestamps
- The function gracefully handles missing columns by returning an empty array rather than raising exceptions
- Session-level plotting is now called with appropriate parameters including the results directory and animal/date identifiers

https://claude.ai/code/session_01Kez8BgNyT4BxVissRCj1Sd