### PR TITLE
Add eye tracking analysis for fixation feedback sessions

### DIFF
--- a/Python/analysis/fixationfeedback_population.py
+++ b/Python/analysis/fixationfeedback_population.py
@@ -35,8 +35,13 @@ from fixationfeedback_session import (
     load_fixation_feedback_data,
     compute_success_trial_times,
     compute_trial_times_by_diameter,
+    compute_fixation_variance_by_diameter,
 )
 from fixation_session import bonsai_to_deg
+from prosaccade_feedback_session import (
+    extract_trial_trajectories,
+    identify_and_filter_failed_trials,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/Python/analysis/fixationfeedback_population.py
+++ b/Python/analysis/fixationfeedback_population.py
@@ -304,6 +304,101 @@ def plot_trial_time_by_diameter_population(
 
 
 # ---------------------------------------------------------------------------
+# Fixation variance population plot
+# ---------------------------------------------------------------------------
+
+def plot_fixation_variance_population(
+    all_session_records: list[dict],
+    animal_ids: list[str],
+    animal_names: list[str],
+    results_dir: Optional[Path] = None,
+    show_plots: bool = True,
+) -> None:
+    """Population mean ± SEM of fixation X variance vs target diameter, per animal.
+
+    Mirrors the layout of plot_population_psychometric.
+    """
+    all_diameters: set[float] = set()
+    for rec in all_session_records:
+        for raw_diam in rec.get("variance_by_diameter", {}).keys():
+            diam_deg = round(float(bonsai_to_deg(raw_diam)), 3)
+            all_diameters.add(diam_deg)
+    diameters = np.array(sorted(all_diameters))
+
+    if len(diameters) == 0:
+        print("Warning: no variance-by-diameter data found — skipping variance population plot")
+        return
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    for a_idx, animal_name in enumerate(animal_names):
+        mean_color = _ANIMAL_MEAN_COLORS[a_idx % len(_ANIMAL_MEAN_COLORS)]
+
+        session_recs = [r for r in all_session_records if r.get("animal_name") == animal_name]
+        n_sessions = len(session_recs)
+        if n_sessions == 0:
+            continue
+
+        var_matrix = np.full((n_sessions, len(diameters)), np.nan)
+        for s_idx, rec in enumerate(session_recs):
+            for raw_diam, var_x in rec.get("variance_by_diameter", {}).items():
+                diam_deg = round(float(bonsai_to_deg(raw_diam)), 3)
+                d_idx_arr = np.where(diameters == diam_deg)[0]
+                if len(d_idx_arr) > 0:
+                    var_matrix[s_idx, d_idx_arr[0]] = var_x
+
+        with np.errstate(all="ignore"):
+            pop_mean = np.nanmean(var_matrix, axis=0)
+            pop_n = np.sum(~np.isnan(var_matrix), axis=0)
+            pop_sem = np.nanstd(var_matrix, axis=0, ddof=1) / np.sqrt(pop_n)
+
+        valid_pop = ~np.isnan(pop_mean)
+        animal_label = animal_name or (animal_ids[a_idx] if a_idx < len(animal_ids) else "")
+        ax.errorbar(
+            diameters[valid_pop], pop_mean[valid_pop], yerr=pop_sem[valid_pop],
+            fmt="o-", color=mean_color, ecolor=mean_color,
+            markersize=10, linewidth=2.5, capsize=5, capthick=2,
+            label=f"{animal_label} mean ± SEM", zorder=5,
+        )
+
+        for d, mean_val, sem_val, n in zip(
+            diameters[valid_pop], pop_mean[valid_pop], pop_sem[valid_pop], pop_n[valid_pop]
+        ):
+            ax.text(d, mean_val + sem_val, f"n={int(n)}",
+                    ha="center", va="bottom", fontsize=9,
+                    fontweight="bold", color=mean_color)
+
+    ax.set_xlabel("Target Diameter (°)", fontsize=14, fontweight="bold")
+    ax.set_ylabel("Fixation Centerpoint X Variance (Var(X))", fontsize=14, fontweight="bold")
+
+    title = "Fixation w Visual Feedback: X Variance vs Target Diameter"
+    label_parts = [p for p in animal_names if p]
+    if label_parts:
+        title += f"\n{' & '.join(label_parts)}"
+    ax.set_title(title, fontsize=14, fontweight="bold")
+
+    x_pad = (diameters.max() - diameters.min()) * 0.08 if len(diameters) > 1 else 0.1
+    ax.set_xlim(diameters.min() - x_pad, diameters.max() + x_pad)
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="best", fontsize=9, framealpha=0.7)
+
+    plt.tight_layout()
+
+    if results_dir is not None:
+        results_dir.mkdir(parents=True, exist_ok=True)
+        prefix = "_".join(aid for aid in animal_ids if aid)
+        if prefix:
+            prefix += "_"
+        for ext in ("png", "svg"):
+            fig.savefig(results_dir / f"{prefix}fixation_wfeedback_variance.{ext}",
+                        bbox_inches="tight")
+
+    if show_plots:
+        plt.show()
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
 # Data loading helper (per animal)
 # ---------------------------------------------------------------------------
 
@@ -343,7 +438,7 @@ def _load_animal_sessions(
 
         print(f"\nLoading {session_id}...")
         try:
-            eot_df, target_df = load_fixation_feedback_data(config.folder_path)
+            eot_df, eye_df, target_df = load_fixation_feedback_data(config.folder_path)
         except Exception as exc:
             print(f"  Error loading {session_id}: {exc}")
             continue
@@ -357,6 +452,13 @@ def _load_animal_sessions(
         avg_trial_time = float(np.nanmean(success_times)) if len(success_times) > 0 else float("nan")
         trial_times_by_diam = compute_trial_times_by_diameter(eot_df, target_df)
 
+        if eye_df is not None:
+            successful_indices = identify_and_filter_failed_trials(target_df, eot_df, exclude_failed=False)
+            trials = extract_trial_trajectories(eot_df, eye_df, target_df, successful_indices)
+            variance_by_diam = compute_fixation_variance_by_diameter(trials)
+        else:
+            variance_by_diam = {}
+
         folder_name = config.folder_path.name
         date_match = re.search(r"\d{4}-\d{2}-\d{2}", folder_name)
         date_str = date_match.group() if date_match else ""
@@ -369,6 +471,7 @@ def _load_animal_sessions(
             "psychometric": psychometric,
             "avg_success_trial_time": avg_trial_time,
             "trial_times_by_diameter": trial_times_by_diam,
+            "variance_by_diameter": variance_by_diam,
         })
 
         n_trials = len(eot_df)
@@ -418,6 +521,13 @@ def analyze_animal(
         results_dir=results_dir,
         show_plots=show_plots,
     )
+    plot_fixation_variance_population(
+        session_records,
+        animal_ids=[animal_id],
+        animal_names=[animal_name],
+        results_dir=results_dir,
+        show_plots=show_plots,
+    )
 
     return pd.concat(summary_rows, ignore_index=True) if summary_rows else pd.DataFrame()
 
@@ -450,6 +560,13 @@ def analyze_animals(
         show_plots=show_plots,
     )
     plot_trial_time_by_diameter_population(
+        all_records,
+        animal_ids=animal_ids,
+        animal_names=animal_names,
+        results_dir=results_dir,
+        show_plots=show_plots,
+    )
+    plot_fixation_variance_population(
         all_records,
         animal_ids=animal_ids,
         animal_names=animal_names,

--- a/Python/analysis/fixationfeedback_session.py
+++ b/Python/analysis/fixationfeedback_session.py
@@ -21,31 +21,45 @@ from typing import Optional, Tuple
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+from matplotlib.patches import Circle
+from matplotlib.lines import Line2D
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from utils.session_loader import load_session
 from eyehead.io import clean_csv
 from fixation_session import plot_psychometric_central_fixation, bonsai_to_deg
+from prosaccade_feedback_session import (
+    extract_trial_trajectories,
+    identify_and_filter_failed_trials,
+    detect_fixations,
+    FIXATION_MIN_DURATION,
+    FIXATION_MAX_MOVEMENT,
+)
 
 
-def load_fixation_feedback_data(folder_path: Path) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    """Load end-of-trial and target CSVs from a fixation feedback session folder.
+def load_fixation_feedback_data(folder_path: Path) -> Tuple[pd.DataFrame, Optional[pd.DataFrame], pd.DataFrame]:
+    """Load end-of-trial, eye position, and target CSVs from a fixation feedback session folder.
 
     Returns
     -------
-    (eot_df, target_df)
+    (eot_df, eye_df, target_df)
         eot_df  – one row per trial, always has 'trial_success'; has 'diameter'
                   when recorded there.
-        target_df – one row per trial, always has 'diameter'.
+        eye_df  – frame-by-frame eye/cursor position (green_x, green_y), or None if
+                  no vstim_go file is found.
+        target_df – one row per trial, always has 'diameter' and 'visible'.
     """
     csv_files = list(folder_path.glob("*.csv"))
 
     endoftrial_file = None
     target_file = None
+    vstim_go_file = None
     for f in csv_files:
         name = f.name.lower()
         if "endoftrial" in name:
             endoftrial_file = f
+        elif "vstim_go" in name:
+            vstim_go_file = f
         elif "vstim_cue" in name or "target" in name:
             target_file = f
 
@@ -74,6 +88,24 @@ def load_fixation_feedback_data(folder_path: Path) -> Tuple[pd.DataFrame, pd.Dat
     eot_df["trial_success"] = eot_df["trial_success"].astype(int)
     print(f"  Loaded {len(eot_df)} end-of-trial events")
 
+    # --- eye / cursor position (vstim_go) ---
+    eye_df = None
+    if vstim_go_file is not None:
+        print(f"\nLoading {vstim_go_file.name}...")
+        eye_arr = np.genfromtxt(clean_csv(str(vstim_go_file)), delimiter=",", skip_header=1, dtype=float)
+        if eye_arr.ndim == 1:
+            eye_arr = eye_arr.reshape(1, -1)
+        n_eye = eye_arr.shape[1]
+        eye_df = pd.DataFrame({
+            "frame": eye_arr[:, 0],
+            "timestamp": eye_arr[:, 1],
+            "green_x": eye_arr[:, 2],
+            "green_y": eye_arr[:, 3],
+            "diameter": eye_arr[:, 4] if n_eye >= 5 else 0.2,
+        })
+        eye_df["frame"] = eye_df["frame"].astype(int)
+        print(f"  Loaded {len(eye_df)} eye position rows")
+
     # --- target (diameter source) ---
     if target_file is not None:
         print(f"\nLoading {target_file.name}...")
@@ -87,17 +119,21 @@ def load_fixation_feedback_data(folder_path: Path) -> Tuple[pd.DataFrame, pd.Dat
         # One row per trial – drop duplicate frames
         if "frame" in target_df.columns:
             target_df = target_df.drop_duplicates(subset=["frame"], keep="first").reset_index(drop=True)
+        # Ensure visible column exists
+        if "visible" not in target_df.columns:
+            target_df["visible"] = 1
         print(f"  Loaded {len(target_df)} target rows")
     elif "diameter" in eot_df.columns:
         # Diameter recorded in endoftrial file – use it directly
         target_df = eot_df[["diameter"]].copy().reset_index(drop=True)
+        target_df["visible"] = 1
     else:
         raise FileNotFoundError(
             f"No target CSV and no 'diameter' column in endoftrial – cannot build psychometric curve. "
             f"Folder: {folder_path}"
         )
 
-    return eot_df, target_df
+    return eot_df, eye_df, target_df
 
 
 
@@ -211,6 +247,302 @@ def plot_trial_time_session(
     return fig
 
 
+def compute_fixation_variance_by_diameter(trials: list[dict]) -> dict[float, float]:
+    """Return {diameter: var_x} of fixation centerpoints, keyed by target diameter."""
+    from collections import defaultdict
+    centerpoints_by_diam: dict[float, list[float]] = defaultdict(list)
+    for trial in trials:
+        if not trial.get('has_eye_data', False):
+            continue
+        diameter = trial.get('target_diameter')
+        if diameter is None:
+            continue
+        eye_x = np.array(trial['eye_x'])
+        eye_y = np.array(trial['eye_y'])
+        eye_times = np.array(trial.get('eye_times', np.arange(len(eye_x))))
+        fixations = detect_fixations(eye_x, eye_y, eye_times, FIXATION_MIN_DURATION, FIXATION_MAX_MOVEMENT)
+        if fixations:
+            start, end, *_ = fixations[-1]
+            centerpoints_by_diam[diameter].append(float(np.mean(eye_x[start:end])))
+    return {
+        diam: float(np.var(xs)) if len(xs) > 1 else float('nan')
+        for diam, xs in centerpoints_by_diam.items()
+    }
+
+
+def plot_trajectories_by_diameter(
+    trials: list[dict],
+    results_dir: Optional[Path] = None,
+    animal_id: Optional[str] = None,
+    session_date: str = "",
+    session_time: Optional[str] = None,
+    min_fixation_duration: float = FIXATION_MIN_DURATION,
+    max_fixation_movement: float = FIXATION_MAX_MOVEMENT,
+    show_plots: bool = True,
+) -> plt.Figure:
+    """Plot fixation points grouped by target diameter.
+
+    Creates a figure with subplots, one for each unique target diameter.
+    Each subplot shows fixation points with successful trials in green and
+    failed trials in red.
+
+    Parameters
+    ----------
+    trials : list of dict
+        List of trial data dictionaries containing eye trajectories.
+    results_dir : Path, optional
+        Directory to save the figure.
+    animal_id : str, optional
+        Animal identifier for filename.
+    session_date : str, optional
+        Session date for title (format: YYYY-MM-DD).
+    session_time : str, optional
+        Session time for title (format: HH:MM).
+    min_fixation_duration : float
+        Minimum fixation duration in seconds.
+    max_fixation_movement : float
+        Maximum movement threshold for fixation.
+    show_plots : bool
+        Whether to call plt.show() on both figures.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        The generated scatter figure.
+    """
+    # Group trials by diameter
+    diameter_trials = {}
+    for trial in trials:
+        if not trial.get('has_eye_data', False):
+            continue
+        diameter = trial.get('target_diameter', None)
+        if diameter is None:
+            continue
+        if diameter not in diameter_trials:
+            diameter_trials[diameter] = []
+        diameter_trials[diameter].append(trial)
+
+    if len(diameter_trials) == 0:
+        print("Warning: No trials with eye data and diameter information found")
+        return None
+
+    # Sort diameters for consistent plotting
+    sorted_diameters = sorted(diameter_trials.keys())
+    n_diameters = len(sorted_diameters)
+
+    # Create subplots arranged in a grid
+    n_cols = min(3, n_diameters)
+    n_rows = int(np.ceil(n_diameters / n_cols))
+
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(6 * n_cols, 5 * n_rows))
+
+    # Make axes always iterable
+    if n_diameters == 1:
+        axes = np.array([axes])
+    axes = axes.flatten()
+
+    # Collect variance data for separate plot
+    variance_data = {'diameters': [], 'variances': [], 'percent_correct': [], 'iti_variances': []}
+
+    # Plot fixations for each diameter
+    for idx, diameter in enumerate(sorted_diameters):
+        ax = axes[idx]
+        trial_list = diameter_trials[diameter]
+
+        n_success = 0
+        n_failed = 0
+        target_x = None
+        target_y = None
+
+        # Store all centerpoints for variance calculation
+        all_centerpoints = []
+        iti_centerpoints = []
+
+        # Collect fixation points from all trials
+        for trial in trial_list:
+            eye_x = np.array(trial['eye_x'])
+            eye_y = np.array(trial['eye_y'])
+            eye_times = np.array(trial.get('eye_times', np.arange(len(eye_x))))
+
+            if target_x is None:
+                target_x = trial['target_x']
+                target_y = trial['target_y']
+
+            is_failed = trial.get('trial_failed', False)
+
+            if is_failed:
+                n_failed += 1
+                color = 'red'
+                marker = 'x'
+            else:
+                n_success += 1
+                color = 'green'
+                marker = 'o'
+
+            # Detect fixations
+            fixations = detect_fixations(eye_x, eye_y, eye_times,
+                                         min_fixation_duration, max_fixation_movement)
+
+            # Plot only the last fixation
+            if len(fixations) > 0:
+                start, end, duration, span = fixations[-1]
+                fix_x = eye_x[start:end]
+                fix_y = eye_y[start:end]
+                ax.plot(fix_x, fix_y, marker, color=color, markersize=6, alpha=0.8)
+
+                # Calculate centerpoint of this fixation
+                centerpoint_x = np.mean(fix_x)
+                centerpoint_y = np.mean(fix_y)
+
+                # Store centerpoint
+                all_centerpoints.append([centerpoint_x, centerpoint_y])
+
+            # # Plot inter-trial fixations in purple (keep comment, no block)
+
+        # Calculate variance of all centerpoints using var_x only
+        if len(all_centerpoints) > 0:
+            all_centerpoints_arr = np.array(all_centerpoints)
+            var_x = np.var(all_centerpoints_arr[:, 0])
+            centerpoint_var = var_x
+        else:
+            centerpoint_var = np.nan
+
+        # Calculate variance of inter-trial centerpoints
+        if len(iti_centerpoints) > 0:
+            iti_centerpoints_arr = np.array(iti_centerpoints)
+            iti_var_x = np.var(iti_centerpoints_arr[:, 0])
+            iti_var = iti_var_x
+        else:
+            iti_var = np.nan
+
+        # Store data for variance plot
+        variance_data['diameters'].append(diameter)
+        variance_data['variances'].append(centerpoint_var)
+        variance_data['iti_variances'].append(iti_var)
+        pct_correct = (n_success / (n_success + n_failed)) * 100 if (n_success + n_failed) > 0 else 0
+        variance_data['percent_correct'].append(pct_correct)
+
+        # Draw target circle
+        circle = Circle((target_x, target_y), diameter / 2,
+                         fill=False, edgecolor='blue', linewidth=2.5, linestyle='--')
+        ax.add_patch(circle)
+
+        # Mark target center
+        ax.plot(target_x, target_y, 'b+', markersize=15, markeredgewidth=3)
+
+        # Set axis limits
+        ax.set_xlim(-1.7, 1.7)
+        ax.set_ylim(-1, 1)
+        ax.set_aspect('equal')
+
+        # Labels and title
+        ax.set_xlabel('X Position', fontsize=10)
+        ax.set_ylabel('Y Position', fontsize=10)
+
+        # Build title WITHOUT variance information
+        title_text = f'Diameter: {diameter:.3f}\n(n={n_success + n_failed}: {n_success} success, {n_failed} failed)'
+
+        ax.set_title(title_text, fontsize=11, fontweight='bold')
+        ax.grid(True, alpha=0.3)
+
+        # Add legend to first subplot only
+        if idx == 0:
+            legend_elements = [
+                Line2D([0], [0], marker='o', color='w', markerfacecolor='green',
+                       markersize=8, label='Success fixations'),
+                Line2D([0], [0], marker='x', color='red', markersize=8,
+                       linewidth=2, label='Failed fixations'),
+                Line2D([0], [0], marker='o', color='w', markerfacecolor='purple',
+                       markersize=8, label='Inter-trial fixations'),
+                Line2D([0], [0], color='blue', linewidth=2, linestyle='--', label='Target'),
+            ]
+            ax.legend(handles=legend_elements, loc='upper right', fontsize=9)
+
+    # Hide extra subplots if we have more subplots than diameters
+    for idx in range(n_diameters, len(axes)):
+        axes[idx].set_visible(False)
+
+    # Overall title
+    title = 'Fixation Points by Target Diameter'
+    if animal_id:
+        title += f'\n{animal_id}'
+    if session_date:
+        title += f' - {session_date}'
+        if session_time:
+            title += f' @ {session_time}'
+    elif session_time:
+        title += f' - {session_time}'
+
+    fig.suptitle(title, fontsize=14, fontweight='bold')
+    plt.tight_layout()
+
+    # Save figure if results directory provided
+    if results_dir:
+        results_dir.mkdir(parents=True, exist_ok=True)
+        prefix = f"{animal_id}_" if animal_id else ""
+        date_suffix = f"_{session_date}" if session_date else ""
+        filename = f"{prefix}fixations_by_diameter{date_suffix}.png"
+        fig.savefig(results_dir / filename, dpi=150, bbox_inches='tight')
+        print(f"Saved fixations by diameter to {results_dir / filename}")
+
+    if show_plots:
+        plt.show()
+    plt.close(fig)
+
+    # Create variance vs diameter plot
+    fig_var, ax_var = plt.subplots(figsize=(10, 7))
+
+    # Plot trial fixation variance (solid blue line)
+    ax_var.plot(variance_data['diameters'], variance_data['variances'], 'o-',
+                linewidth=2, markersize=10, color='steelblue',
+                markerfacecolor='lightblue', markeredgecolor='steelblue',
+                markeredgewidth=2, label='Trial fixations')
+
+    # Plot inter-trial fixation variance (dashed purple line)
+    valid_iti = [(d, v) for d, v in zip(variance_data['diameters'], variance_data['iti_variances']) if not np.isnan(v)]
+    if valid_iti:
+        iti_diameters, iti_variances = zip(*valid_iti)
+        ax_var.plot(iti_diameters, iti_variances, 'o--',
+                    linewidth=2, markersize=10, color='purple',
+                    markerfacecolor='lavender', markeredgecolor='purple',
+                    markeredgewidth=2, label='Inter-trial fixations')
+
+    # Add % correct labels
+    for d, v, pct in zip(variance_data['diameters'], variance_data['variances'], variance_data['percent_correct']):
+        if not np.isnan(v):
+            ax_var.annotate(f'{pct:.1f}%', xy=(d, v), xytext=(0, 10), textcoords='offset points',
+                            ha='center', fontsize=10, fontweight='bold',
+                            bbox=dict(boxstyle='round,pad=0.3', facecolor='yellow', alpha=0.7))
+
+    ax_var.set_xlabel('Target Diameter', fontsize=12, fontweight='bold')
+    ax_var.set_ylabel('Fixation Centerpoint X Variance (Var(X))', fontsize=12, fontweight='bold')
+    var_title = 'Fixation Centerpoint Variance vs Target Diameter'
+    if animal_id:
+        var_title += f'\n{animal_id}'
+    if session_date:
+        var_title += f' - {session_date}'
+        if session_time:
+            var_title += f' @ {session_time}'
+    elif session_time:
+        var_title += f' - {session_time}'
+    ax_var.set_title(var_title, fontsize=14, fontweight='bold')
+    ax_var.grid(True, alpha=0.3)
+    ax_var.legend(loc='best', fontsize=11)
+
+    if results_dir:
+        prefix = f"{animal_id}_" if animal_id else ""
+        date_suffix = f"_{session_date}" if session_date else ""
+        filename_var = f"{prefix}fixation_variance_by_diameter{date_suffix}.png"
+        fig_var.savefig(results_dir / filename_var, dpi=150, bbox_inches='tight')
+        print(f"Saved fixation variance by diameter to {results_dir / filename_var}")
+
+    if show_plots:
+        plt.show()
+    plt.close(fig_var)
+
+    return fig
+
+
 def analyze_session(
     folder_path: str | Path,
     results_dir: Optional[str | Path] = None,
@@ -251,7 +583,7 @@ def analyze_session(
         if m:
             animal_id = m.group(1)
 
-    eot_df, target_df = load_fixation_feedback_data(folder_path)
+    eot_df, eye_df, target_df = load_fixation_feedback_data(folder_path)
 
     print("\nGenerating psychometric curve...")
     fig = plot_psychometric_central_fixation(
@@ -266,6 +598,14 @@ def analyze_session(
     plot_trial_time_session(
         eot_df, target_df, results_dir, animal_id, date_str, show_plots=show_plots
     )
+
+    if eye_df is not None:
+        print("\nGenerating trajectory plots by diameter...")
+        successful_indices = identify_and_filter_failed_trials(target_df, eot_df, exclude_failed=False)
+        trials = extract_trial_trajectories(eot_df, eye_df, target_df, successful_indices)
+        plot_trajectories_by_diameter(
+            trials, results_dir, animal_id, date_str, session_time, show_plots=show_plots
+        )
 
     return pd.DataFrame({
         "session_id": [folder_name],

--- a/Python/analysis/prosaccade_feedback_session.py
+++ b/Python/analysis/prosaccade_feedback_session.py
@@ -2632,7 +2632,7 @@ def plot_trajectories_by_diameter(trials: list[dict], results_dir: Optional[Path
             all_centerpoints_arr = np.array(all_centerpoints)
             var_x = np.var(all_centerpoints_arr[:, 0])
             var_y = np.var(all_centerpoints_arr[:, 1])
-            centerpoint_var = var_x + var_y
+            centerpoint_var = var_x
         else:
             centerpoint_var = np.nan
         
@@ -2641,7 +2641,7 @@ def plot_trajectories_by_diameter(trials: list[dict], results_dir: Optional[Path
             iti_centerpoints_arr = np.array(iti_centerpoints)
             iti_var_x = np.var(iti_centerpoints_arr[:, 0])
             iti_var_y = np.var(iti_centerpoints_arr[:, 1])
-            iti_var = iti_var_x + iti_var_y
+            iti_var = iti_var_x
         else:
             iti_var = np.nan
 
@@ -2748,7 +2748,7 @@ def plot_trajectories_by_diameter(trials: list[dict], results_dir: Optional[Path
                             bbox=dict(boxstyle='round,pad=0.3', facecolor='yellow', alpha=0.7))
     
     ax_var.set_xlabel('Target Diameter', fontsize=12, fontweight='bold')
-    ax_var.set_ylabel('Fixation Centerpoint Variance (Var(X) + Var(Y))', fontsize=12, fontweight='bold')
+    ax_var.set_ylabel('Fixation Centerpoint X Variance (Var(X))', fontsize=12, fontweight='bold')
     var_title = 'Fixation Centerpoint Variance vs Target Diameter'
     if animal_id:
         var_title += f'\n{animal_id}'


### PR DESCRIPTION
## Summary
This PR extends the fixation feedback analysis pipeline to include eye tracking data processing and visualization. It adds support for loading eye position data (vstim_go files), detecting fixations, and analyzing fixation variance across different target diameters.

## Key Changes

### fixationfeedback_session.py
- **Enhanced data loading**: Modified `load_fixation_feedback_data()` to return eye position data (`eye_df`) in addition to end-of-trial and target data
  - Now loads vstim_go CSV files containing frame-by-frame eye/cursor position (green_x, green_y)
  - Returns tuple of `(eot_df, eye_df, target_df)` instead of `(eot_df, target_df)`
  - Ensures target_df has a 'visible' column for consistency

- **New visualization function**: Added `plot_trajectories_by_diameter()` to visualize fixation points grouped by target diameter
  - Creates subplots for each unique target diameter
  - Shows successful trials in green and failed trials in red
  - Displays target circles and calculates fixation centerpoint variance
  - Generates a companion variance vs. diameter plot with success rate annotations
  - Saves both trajectory and variance plots to results directory

- **New analysis function**: Added `compute_fixation_variance_by_diameter()` to calculate fixation centerpoint X variance keyed by target diameter

- **Updated analyze_session()**: Integrated eye tracking analysis when eye_df is available
  - Extracts trial trajectories and generates trajectory plots by diameter

### fixationfeedback_population.py
- **New population-level analysis**: Added `plot_fixation_variance_population()` to plot mean ± SEM of fixation X variance vs. target diameter across animals
  - Mirrors the layout of existing population psychometric plots
  - Includes sample size annotations per diameter

- **Updated data loading**: Modified `_load_animal_sessions()` to compute and store variance_by_diameter for each session when eye data is available

- **Updated analysis functions**: Both `analyze_animal()` and `analyze_animals()` now call the new variance population plot function

### prosaccade_feedback_session.py
- **Variance calculation fix**: Changed centerpoint variance calculation from `var_x + var_y` to `var_x` only for consistency with fixation feedback analysis

## Implementation Details
- Reuses existing fixation detection utilities (`detect_fixations`, `FIXATION_MIN_DURATION`, `FIXATION_MAX_MOVEMENT`) from prosaccade_feedback_session
- Imports helper functions (`extract_trial_trajectories`, `identify_and_filter_failed_trials`) from prosaccade_feedback_session for consistency
- Eye data is optional; analysis gracefully handles sessions without vstim_go files
- Variance calculations use only X-axis variance (Var(X)) for fixation centerpoints

https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax