### PR TITLE
Add fixation X-variance plots to fixationfeedback session and population

### DIFF
--- a/Python/analysis/fixationfeedback_population.py
+++ b/Python/analysis/fixationfeedback_population.py
@@ -453,7 +453,7 @@ def _load_animal_sessions(
         trial_times_by_diam = compute_trial_times_by_diameter(eot_df, target_df)
 
         if eye_df is not None:
-            successful_indices = identify_and_filter_failed_trials(target_df, eot_df, exclude_failed=False)
+            _, _failed, successful_indices = identify_and_filter_failed_trials(target_df, eot_df, exclude_failed=False)
             trials = extract_trial_trajectories(eot_df, eye_df, target_df, successful_indices)
             variance_by_diam = compute_fixation_variance_by_diameter(trials)
         else:

--- a/Python/analysis/fixationfeedback_session.py
+++ b/Python/analysis/fixationfeedback_session.py
@@ -601,7 +601,7 @@ def analyze_session(
 
     if eye_df is not None:
         print("\nGenerating trajectory plots by diameter...")
-        successful_indices = identify_and_filter_failed_trials(target_df, eot_df, exclude_failed=False)
+        _, _failed, successful_indices = identify_and_filter_failed_trials(target_df, eot_df, exclude_failed=False)
         trials = extract_trial_trajectories(eot_df, eye_df, target_df, successful_indices)
         plot_trajectories_by_diameter(
             trials, results_dir, animal_id, date_str, session_time, show_plots=show_plots


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Variance metric**: Changed from `Var(X) + Var(Y)` to `Var(X)` only across all three files (`prosaccade_feedback_session`, `fixationfeedback_session`, `fixationfeedback_population`)
- **`fixationfeedback_session.py`**: Added eye data loading (`vstim_go` file), trial trajectory extraction via `extract_trial_trajectories`, `compute_fixation_variance_by_diameter`, and `plot_trajectories_by_diameter` (fixation scatter grid + variance line plot, ported from prosaccade without random walk)
- **`fixationfeedback_population.py`**: Added `plot_fixation_variance_population` (mean ± SEM per animal per diameter in degrees), wired into `analyze_animal` and `analyze_animals`
- **Bug fix**: Corrected unpacking of `identify_and_filter_failed_trials` return value (was passing full 3-tuple as `successful_indices`)

## Test plan

- [ ] Run `fixationfeedback_session.py` on a session with eye data and confirm scatter grid + variance plot are generated and saved
- [ ] Run `fixationfeedback_population.py` across multiple sessions and confirm population variance plot (mean ± SEM) is generated
- [ ] Confirm variance plots now show Var(X) only (not summed with Var(Y))

https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax)_