### PR TITLE
Add random walk chance baseline to fixationfeedback psychometric plots

### DIFF
--- a/Python/analysis/fixationfeedback_population.py
+++ b/Python/analysis/fixationfeedback_population.py
@@ -41,6 +41,7 @@ from fixation_session import bonsai_to_deg
 from prosaccade_feedback_session import (
     extract_trial_trajectories,
     identify_and_filter_failed_trials,
+    calculate_random_walk_chance_performance,
 )
 
 
@@ -173,6 +174,29 @@ def plot_population_psychometric(
             ax.text(d, mean_val + sd_val + 3, f"n={int(n)}",
                     ha="center", va="bottom", fontsize=9,
                     fontweight="bold", color=mean_color)
+
+        # Random walk chance overlay (dashed, same colour family, per animal)
+        rw_matrix = np.full((n_sessions, len(diameters)), np.nan)
+        for s_idx, rec in enumerate(session_recs):
+            rw_by_diam = rec.get("random_walk_chance", {}).get("by_diameter", {})
+            for raw_diam, rate in rw_by_diam.items():
+                deg = round(float(bonsai_to_deg(raw_diam)), 3)
+                d_idx_arr = np.where(np.isclose(diameters, deg))[0]
+                if len(d_idx_arr):
+                    rw_matrix[s_idx, d_idx_arr[0]] = rate * 100
+
+        with np.errstate(all="ignore"):
+            rw_mean = np.nanmean(rw_matrix, axis=0)
+            rw_sd = np.nanstd(rw_matrix, axis=0, ddof=1)
+
+        valid_rw = ~np.isnan(rw_mean)
+        if valid_rw.sum() >= 2:
+            ax.errorbar(
+                diameters[valid_rw], rw_mean[valid_rw], yerr=rw_sd[valid_rw],
+                fmt="o--", color=mean_color, ecolor=mean_color,
+                markersize=7, linewidth=1.5, capsize=4, capthick=1.5,
+                alpha=0.5, label=f"{animal_label} random walk chance",
+            )
 
     ax.axhline(100, color="green", linestyle="--", alpha=0.3, linewidth=1)
     ax.axhline(0,   color="red",   linestyle="--", alpha=0.3, linewidth=1)
@@ -452,12 +476,13 @@ def _load_animal_sessions(
         avg_trial_time = float(np.nanmean(success_times)) if len(success_times) > 0 else float("nan")
         trial_times_by_diam = compute_trial_times_by_diameter(eot_df, target_df)
 
+        rw_chance: dict = {}
+        variance_by_diam: dict = {}
         if eye_df is not None:
             _, _failed, successful_indices = identify_and_filter_failed_trials(target_df, eot_df, exclude_failed=False)
             trials = extract_trial_trajectories(eot_df, eye_df, target_df, successful_indices)
             variance_by_diam = compute_fixation_variance_by_diameter(trials)
-        else:
-            variance_by_diam = {}
+            rw_chance = calculate_random_walk_chance_performance(trials)
 
         folder_name = config.folder_path.name
         date_match = re.search(r"\d{4}-\d{2}-\d{2}", folder_name)
@@ -472,6 +497,7 @@ def _load_animal_sessions(
             "avg_success_trial_time": avg_trial_time,
             "trial_times_by_diameter": trial_times_by_diam,
             "variance_by_diameter": variance_by_diam,
+            "random_walk_chance": rw_chance,
         })
 
         n_trials = len(eot_df)

--- a/Python/analysis/fixationfeedback_session.py
+++ b/Python/analysis/fixationfeedback_session.py
@@ -32,6 +32,8 @@ from prosaccade_feedback_session import (
     extract_trial_trajectories,
     identify_and_filter_failed_trials,
     detect_fixations,
+    calculate_random_walk_chance_performance,
+    calculate_trial_success_from_fixations,
     FIXATION_MIN_DURATION,
     FIXATION_MAX_MOVEMENT,
 )
@@ -585,9 +587,18 @@ def analyze_session(
 
     eot_df, eye_df, target_df = load_fixation_feedback_data(folder_path)
 
+    trials = None
+    rw_chance = None
+    if eye_df is not None:
+        _, _failed, successful_indices = identify_and_filter_failed_trials(target_df, eot_df, exclude_failed=False)
+        trials = extract_trial_trajectories(eot_df, eye_df, target_df, successful_indices)
+        print("\nCalculating random walk chance performance...")
+        rw_chance = calculate_random_walk_chance_performance(trials, results_dir=results_dir)
+
     print("\nGenerating psychometric curve...")
     fig = plot_psychometric_central_fixation(
-        eot_df, target_df, results_dir, animal_id, date_str, session_time
+        eot_df, target_df, results_dir, animal_id, date_str, session_time,
+        random_walk_chance=rw_chance,
     )
     if fig is not None:
         if show_plots:
@@ -599,10 +610,8 @@ def analyze_session(
         eot_df, target_df, results_dir, animal_id, date_str, show_plots=show_plots
     )
 
-    if eye_df is not None:
+    if trials is not None:
         print("\nGenerating trajectory plots by diameter...")
-        _, _failed, successful_indices = identify_and_filter_failed_trials(target_df, eot_df, exclude_failed=False)
-        trials = extract_trial_trajectories(eot_df, eye_df, target_df, successful_indices)
         plot_trajectories_by_diameter(
             trials, results_dir, animal_id, date_str, session_time, show_plots=show_plots
         )


### PR DESCRIPTION
## Summary

- **Session**: trials are now built before the psychometric plot so that `calculate_random_walk_chance_performance` can run on them; the result is passed to `plot_psychometric_central_fixation` as `random_walk_chance=`, adding the dashed Markov chance baseline to the per-session psychometric curve
- **Population**: each session record now stores its `random_walk_chance`; `plot_population_psychometric` averages these across sessions per animal and overlays a dashed mean ± SD chance curve in the matching animal colour

## Test plan

- [ ] Run `fixationfeedback_session.py` on a session with eye data and confirm the psychometric curve shows both the actual success rate and a dashed random walk chance line
- [ ] Run `fixationfeedback_population.py` across multiple sessions and confirm the population psychometric plot shows dashed chance curves per animal alongside the solid mean ± SD success rate curves

https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax)_