### PR TITLE
Fix shuffle chance to use last fixation point, not mean

### DIFF
--- a/Python/analysis/fixationfeedback_session.py
+++ b/Python/analysis/fixationfeedback_session.py
@@ -553,10 +553,11 @@ def calculate_shuffle_chance_by_diameter(
 ) -> dict:
     """Diameter-shuffle null model for psychometric chance level.
 
-    Holds actual fixation centerpoints fixed and permutes target diameters
-    across trials. A trial counts as successful when the fixation centerpoint
-    falls within the shuffled contact threshold
-    (shuffled_target_radius + cursor_radius).
+    Holds actual fixation endpoints fixed and permutes target diameters
+    across trials. A trial counts as successful when the last point of the
+    last fixation falls within the shuffled contact threshold
+    (shuffled_target_radius + cursor_radius), matching the criterion used
+    by calculate_trial_success_from_fixations().
 
     Returns
     -------
@@ -580,8 +581,8 @@ def calculate_shuffle_chance_by_diameter(
             continue
         start, end, *_ = fixations[-1]
         valid.append({
-            'cx': float(np.mean(eye_x[start:end])),
-            'cy': float(np.mean(eye_y[start:end])),
+            'cx': float(eye_x[end - 1]),
+            'cy': float(eye_y[end - 1]),
             'target_x': trial['target_x'],
             'target_y': trial['target_y'],
             'diameter': trial['target_diameter'],


### PR DESCRIPTION
## Summary

Fixes `calculate_shuffle_chance_by_diameter()` to use the **last point** of the last fixation when scoring shuffle trials, matching the criterion in the verified `calculate_trial_success_from_fixations()`:

```python
# Before (incorrect)
'cx': float(np.mean(eye_x[start:end])),
'cy': float(np.mean(eye_y[start:end])),

# After (correct)
'cx': float(eye_x[end - 1]),
'cy': float(eye_y[end - 1]),
```

`calculate_trial_success_from_fixations()` checks `eye_x[end_idx - 1]` (the final sample of the fixation window). Using the mean instead was inconsistent with how actual trial success is determined.

## Test plan

- [ ] Run `fixationfeedback_session.py` on a session and confirm shuffle chance curve appears on psychometric plot
- [ ] Shuffle chance values should be consistent with actual success rates (not systematically off)

https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax)_