### PR TITLE
Add peri-target eye velocity plot (success vs failed) to fixationfeedback session

### DIFF
--- a/Python/analysis/fixationfeedback_session.py
+++ b/Python/analysis/fixationfeedback_session.py
@@ -528,6 +528,121 @@ def plot_trajectories_by_diameter(
     return fig
 
 
+def plot_pericue_velocity_by_outcome(
+    trials: list[dict],
+    pre_s: float = 1.0,
+    post_s: float = 5.0,
+    bin_s: float = 0.1,
+    results_dir: Optional[Path] = None,
+    animal_id: str = "",
+    session_date: str = "",
+    session_time: Optional[str] = None,
+    show_plots: bool = True,
+) -> Optional[plt.Figure]:
+    """Plot peri-target-onset eye path length, split by trial outcome.
+
+    Aligns each trial to target onset (t=0), bins eye path length, and
+    baseline-corrects by subtracting the t=0 bin. Success and failed trials
+    are overlaid as mean ± SEM.
+    """
+    valid = [t for t in trials if t.get('has_eye_data', False)
+             and len(t.get('eye_x', [])) > 1]
+    if not valid:
+        print("  Warning: no trials with eye data — skipping peri-cue plot")
+        return None
+
+    bin_edges = np.arange(-pre_s - bin_s / 2, post_s + bin_s, bin_s)
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+    n_bins = len(bin_centers)
+    baseline_idx = int(np.argmin(np.abs(bin_centers)))
+
+    success_paths, failed_paths = [], []
+
+    for trial in valid:
+        eye_x = np.array(trial['eye_x'])
+        eye_y = np.array(trial['eye_y'])
+        eye_times = np.array(trial['eye_times'])
+        rel_times = eye_times - trial['start_time']
+
+        row = np.full(n_bins, np.nan)
+        for b, (t0, t1) in enumerate(zip(bin_edges[:-1], bin_edges[1:])):
+            mask = (rel_times >= t0) & (rel_times < t1)
+            if mask.sum() < 2:
+                continue
+            dx = np.diff(eye_x[mask])
+            dy = np.diff(eye_y[mask])
+            row[b] = float(np.sum(np.sqrt(dx**2 + dy**2)))
+
+        # Baseline-correct by subtracting the cue-onset bin
+        if not np.isnan(row[baseline_idx]):
+            row -= row[baseline_idx]
+        else:
+            row[:] = np.nan
+
+        if trial.get('trial_failed', False):
+            failed_paths.append(row)
+        else:
+            success_paths.append(row)
+
+    def _mean_sem(rows):
+        if not rows:
+            return None, None
+        mat = np.vstack(rows)
+        n = np.sum(~np.isnan(mat), axis=0)
+        mean = np.nanmean(mat, axis=0)
+        with np.errstate(invalid='ignore'):
+            sem = np.nanstd(mat, axis=0, ddof=1) / np.sqrt(np.maximum(n, 1))
+        sem[n < 2] = np.nan
+        return mean, sem
+
+    s_mean, s_sem = _mean_sem(success_paths)
+    f_mean, f_sem = _mean_sem(failed_paths)
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.axvline(0, color='0.35', linestyle='--', linewidth=1.2, label='Target onset')
+    ax.axhline(0, color='0.7', linestyle='-', linewidth=0.8)
+
+    if s_mean is not None:
+        ax.plot(bin_centers, s_mean, color='steelblue', linewidth=2,
+                label=f'Success (n={len(success_paths)})')
+        ax.fill_between(bin_centers, s_mean - s_sem, s_mean + s_sem,
+                        color='steelblue', alpha=0.25)
+
+    if f_mean is not None:
+        ax.plot(bin_centers, f_mean, color='tomato', linewidth=2,
+                label=f'Failed (n={len(failed_paths)})')
+        ax.fill_between(bin_centers, f_mean - f_sem, f_mean + f_sem,
+                        color='tomato', alpha=0.25)
+
+    ax.set_xlabel('Time relative to target onset (s)', fontsize=12)
+    ax.set_ylabel(f'Eye path length ({bin_s:.2f}s bins, baseline-corrected)', fontsize=11)
+
+    title = 'Peri-target Eye Movement: Success vs Failed'
+    if animal_id:
+        title += f'\n{animal_id}'
+    if session_date:
+        title += f' – {session_date}'
+        if session_time:
+            title += f' @ {session_time}'
+    ax.set_title(title, fontsize=13, fontweight='bold')
+    ax.legend(fontsize=11)
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+
+    if results_dir:
+        results_dir.mkdir(parents=True, exist_ok=True)
+        prefix = f"{animal_id}_" if animal_id else ""
+        date_tag = f"_{session_date}" if session_date else ""
+        for ext in ('png', 'svg'):
+            fig.savefig(results_dir / f"{prefix}pericue_velocity{date_tag}.{ext}",
+                        bbox_inches='tight')
+
+    if show_plots:
+        plt.show()
+    plt.close(fig)
+    return fig
+
+
 def calculate_shuffle_chance_by_diameter(
     trials: list[dict],
     n_shuffles: int = 1000,
@@ -684,6 +799,12 @@ def analyze_session(
     )
 
     if trials is not None:
+        print("\nGenerating peri-target velocity plot...")
+        plot_pericue_velocity_by_outcome(
+            trials, results_dir=results_dir, animal_id=animal_id,
+            session_date=date_str, session_time=session_time, show_plots=show_plots,
+        )
+
         print("\nGenerating trajectory plots by diameter...")
         plot_trajectories_by_diameter(
             trials, results_dir, animal_id, date_str, session_time, show_plots=show_plots


### PR DESCRIPTION
## Summary

Adds `plot_pericue_velocity_by_outcome()` to `fixationfeedback_session.py`, called automatically from `analyze_session` when eye data is available.

**What it shows:** Eye path length binned in 100 ms windows aligned to target onset (t = 0), baseline-corrected at cue onset, split into success (blue) vs failed (red) trials with mean ± SEM shading.

**What to look for:** If the animal is genuinely fixating in response to the target, success trials should show a sharp drop in eye movement shortly after t = 0. Failed trials would either not drop, or drop and then drift back out before the trial ends.

Mirrors the approach of `plot_pericue_path_length` / `_compute_path_bins` in `fixation_session.py`, adapted to work directly from the `trials` list.

## Test plan

- [ ] Run `fixationfeedback_session.py` on a session with eye data — confirm `pericue_velocity_<date>.png` is saved
- [ ] Success curve should drop after t=0 and stay low; failed curve should behave differently
- [ ] Check that baseline correction makes both curves pass through ~0 at t=0

https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax)_