### PR TITLE
Fix peri-target velocity plot, NameError, and RuntimeWarning in fixation feedback session

### DIFF
--- a/Python/analysis/fixationfeedback_session.py
+++ b/Python/analysis/fixationfeedback_session.py
@@ -412,7 +412,7 @@ def plot_trajectories_by_diameter(
         # Store data for variance plot
         variance_data['diameters'].append(diameter)
         variance_data['variances'].append(centerpoint_var)
-        variance_data['iti_variances'].append(iti_var)
+        variance_data['iti_variances'].append(np.nan)
         pct_correct = (n_success / (n_success + n_failed)) * 100 if (n_success + n_failed) > 0 else 0
         variance_data['percent_correct'].append(pct_correct)
 
@@ -589,9 +589,10 @@ def plot_pericue_velocity_by_outcome(
             return None, None
         mat = np.vstack(rows)
         n = np.sum(~np.isnan(mat), axis=0)
-        mean = np.nanmean(mat, axis=0)
-        with np.errstate(invalid='ignore'):
+        with np.errstate(all='ignore'):
+            mean = np.nanmean(mat, axis=0)
             sem = np.nanstd(mat, axis=0, ddof=1) / np.sqrt(np.maximum(n, 1))
+        mean[n == 0] = np.nan
         sem[n < 2] = np.nan
         return mean, sem
 

--- a/Python/analysis/fixationfeedback_session.py
+++ b/Python/analysis/fixationfeedback_session.py
@@ -573,11 +573,17 @@ def plot_pericue_velocity_by_outcome(
             dy = np.diff(eye_y[mask])
             row[b] = float(np.sum(np.sqrt(dx**2 + dy**2)))
 
-        # Baseline-correct by subtracting the cue-onset bin
+        # Baseline-correct: subtract the t=0 bin; if that bin has no data
+        # (eye data starts just after t=0), fall back to the nearest non-NaN bin.
         if not np.isnan(row[baseline_idx]):
             row -= row[baseline_idx]
         else:
-            row[:] = np.nan
+            nonnans = np.where(~np.isnan(row))[0]
+            if len(nonnans) > 0:
+                fallback = nonnans[np.argmin(np.abs(bin_centers[nonnans]))]
+                row -= row[fallback]
+            else:
+                row[:] = np.nan
 
         if trial.get('trial_failed', False):
             failed_paths.append(row)


### PR DESCRIPTION
## Summary

- **Empty peri-target velocity plot**: Eye trajectories from `extract_trial_trajectories` start at target onset (t=0), so there is no pre-trial data. When the first eye frame lands just after t=0, the baseline bin had < 2 samples and the entire trial row was discarded. Now falls back to the nearest non-NaN bin to t=0 so baseline correction works even when the exact t=0 window is thin.
- **NameError `iti_var` not defined**: In `plot_trajectories_by_diameter`, the ITI fixation block is commented out so `iti_var` was never assigned. Fixed by appending `np.nan` instead.
- **RuntimeWarning (mean of empty slice)**: In `_mean_sem` helper of `plot_pericue_velocity_by_outcome`, wrapped `nanmean`/`nanstd` in `np.errstate(all='ignore')` and set `mean[n==0] = np.nan`.

## Test plan

- [ ] Run `analyze_session` on a fixation feedback session with eye data and confirm the peri-target velocity plot renders with success/failed traces
- [ ] Confirm no `NameError` when trajectory plots are generated
- [ ] Confirm no `RuntimeWarning` printed during peri-target velocity plot generation

https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaZvSpA1KWpoab2FMgLoax)_