### PR TITLE
Align saccade plotting with trial-based latency analysis

### DIFF
--- a/Python/analysis/prosaccade_session.py
+++ b/Python/analysis/prosaccade_session.py
@@ -142,6 +142,80 @@ def find_first_saccade_per_trial(
 
     return np.array(latencies), np.array(congruent, dtype=bool)
 
+
+def first_saccade_indices_by_direction(
+    data: SessionData,
+    saccades: Dict[str, np.ndarray],
+    config,
+    max_latency: float = 1.5,
+    frames_key: str = "saccade_frames_xy",
+    indices_key: str = "saccade_indices_xy",
+) -> Dict[str, np.ndarray]:
+    """First-saccade eye indices per trial, grouped by stimulus direction.
+
+    Selects, for every trial, the *first* saccade in the same reward window
+    used by :func:`find_first_saccade_per_trial` /
+    :func:`analyze_latency_by_outcome` — i.e. between target onset
+    (``go_frame``) and that trial's actual end (``end_of_trial_frame``),
+    capped at ``max_latency`` — and returns the corresponding index into the
+    eye-position arrays. This is the same saccade the online task scored for
+    reward.
+
+    ``frames_key`` / ``indices_key`` select which saccade stream to search:
+    the translational stream (``saccade_frames_xy`` / ``saccade_indices_xy``,
+    the default) or the torsional stream (``saccade_frames_theta`` /
+    ``saccade_indices_theta``). Returns an empty dict if that stream is absent
+    or empty.
+
+    Trials are grouped into direction labels exactly as :func:`organize_stims`
+    groups them, so the returned dict can be dropped straight into
+    :func:`eyehead.sort_saccades` in place of its fixed-window search.
+    """
+    ttl_freq = config.ttl_freq
+    go_frame = data.go_frame
+    go_dir_x = data.go_direction_x
+    go_dir_y = data.go_direction_y
+    end_frame = data.end_of_trial_frame
+    if end_frame is None:
+        warnings.warn(
+            "No end_of_trial data available; falling back to a flat "
+            f"{max_latency}s latency cap instead of each trial's actual end."
+        )
+        end_frame = go_frame + max_latency * ttl_freq
+
+    saccade_frames = saccades.get(frames_key)
+    saccade_indices = saccades.get(indices_key)
+    if saccade_frames is None or saccade_indices is None or len(saccade_frames) == 0:
+        return {}
+    saccade_frames = np.asarray(saccade_frames)
+    saccade_indices = np.asarray(saccade_indices)
+
+    first_idx = np.full(len(go_frame), -1, dtype=int)
+    for i, (f, end_f) in enumerate(zip(go_frame, end_frame)):
+        valid = (saccade_frames > f) & (saccade_frames < end_f)
+        if not np.any(valid):
+            continue
+        rel_valid = (saccade_frames[valid] - f) / ttl_freq
+        first = np.argmin(rel_valid)
+        if rel_valid[first] > max_latency:
+            continue
+        first_idx[i] = saccade_indices[valid][first]
+
+    have = first_idx >= 0
+    groups: Dict[str, np.ndarray] = {}
+    if go_dir_x is not None and np.any(np.asarray(go_dir_x) != 0):
+        go_dir_x = np.asarray(go_dir_x)
+        groups["Left"] = first_idx[have & (go_dir_x < 0)]
+        groups["Right"] = first_idx[have & (go_dir_x > 0)]
+    if go_dir_y is not None and np.any(np.asarray(go_dir_y) != 0):
+        go_dir_y = np.asarray(go_dir_y)
+        groups["Down"] = first_idx[have & (go_dir_y < 0)]
+        groups["Up"] = first_idx[have & (go_dir_y > 0)]
+    if not groups:
+        groups["All"] = first_idx[have]
+    return groups
+
+
 def find_precue_saccade_per_trial(
     data: SessionData,
     saccades: Dict[str, np.ndarray],
@@ -512,7 +586,17 @@ def main(session_id: str) -> pd.DataFrame:
 
         }
     )
-    sorted_data,left_angle,right_angle,fig_sorted, _ = sort_saccades(config, saccade_cfg, saccades, stim_type=stim_type, plot=True)
+    first_saccades = first_saccade_indices_by_direction(data, saccades, config)
+    first_saccades_theta = first_saccade_indices_by_direction(
+        data, saccades, config,
+        frames_key="saccade_frames_theta", indices_key="saccade_indices_theta",
+    )
+    sorted_data,left_angle,right_angle,fig_sorted, _ = sort_saccades(
+        config, saccade_cfg, saccades, stim_type=stim_type,
+        first_saccade_indices=first_saccades,
+        first_saccade_indices_theta=first_saccades_theta or None,
+        plot=True,
+    )
     if fig_sorted is not None:
         plt.close(fig_sorted)
 

--- a/Python/eyehead/analysis.py
+++ b/Python/eyehead/analysis.py
@@ -561,6 +561,8 @@ def sort_saccades(
     saccade_config: SaccadeConfig,
     saccades: Dict[str, np.ndarray],
     stim_type: str = "None",
+    first_saccade_indices: Optional[Dict[str, np.ndarray]] = None,
+    first_saccade_indices_theta: Optional[Dict[str, np.ndarray]] = None,
     plot: bool = False,
 ) -> Dict[str, np.ndarray] | Tuple[Dict[str, np.ndarray], plt.Figure, Tuple[plt.Axes, plt.Axes, plt.Axes]]:
     """Sort saccades by stimulus and optionally plot summaries.
@@ -569,6 +571,20 @@ def sort_saccades(
     ----------
     config, saccade_config, saccades, stim_type :
         Same as in the original :func:`sort_plot_saccades`.
+    first_saccade_indices : dict, optional
+        Mapping of stimulus-direction label (``"Left"``, ``"Right"``, ...) to
+        the eye-position indices of each trial's first saccade in the online
+        reward window (see
+        :func:`prosaccade_session.first_saccade_indices_by_direction`). When
+        provided, the per-condition translational figures plot exactly these
+        first saccades instead of searching a fixed ``saccade_win`` window, so
+        they match the latency/congruency analysis. The session-wide "All"
+        figure is unaffected and still shows every detected saccade.
+    first_saccade_indices_theta : dict, optional
+        Same as ``first_saccade_indices`` but for the torsional stream
+        (indices into ``saccade_indices_theta``); used for the per-condition
+        torsion overlay/histogram so torsion is drawn from the same reward
+        window. Falls back to the fixed ``saccade_win`` search when omitted.
     plot : bool, optional
         When ``True`` the function generates the same diagnostic plots as
         before and returns them alongside the sorted saccade indices.
@@ -667,7 +683,7 @@ def sort_saccades(
         ax_quiver.set_ylabel("Y (°)")
         ax_quiver.set_title(
             f"{session_name}\n"
-            + f"All translational saccades ({n_all}) — {eye_name}  (stim: {stim_type})\n"
+            + f"ALL saccades in session ({n_all}) — not trial-aligned — {eye_name}  (stim: {stim_type})\n"
             + f"saccade_thresh = {saccade_config.saccade_threshold}, "
             f"saccade_win = {saccade_config.saccade_win}s\n"
             + f"blink_thresh = {saccade_config.blink_threshold}, "
@@ -704,20 +720,28 @@ def sort_saccades(
     for label, frames in stim_frames.items():
         if label == "All":
             continue
-        idx_buf = []
-        sorted_pairs_xy = sorted(zip(saccade_frames_xy, saccade_indices_xy))
-        for f in frames:
-            lower_bound = max(f + plot_window[0], 0)
-            upper_bound = min(f + plot_window[-1], saccade_frames_xy.max())
-            for sf, idx in sorted_pairs_xy:
-                if sf < lower_bound:
-                    continue
-                elif sf <= upper_bound:
-                    idx_buf.append(idx)
-                    break
-                else:
-                    break
-        idx_use = np.array(idx_buf, dtype=int)
+        if first_saccade_indices is not None:
+            # First saccade per trial in the online reward window
+            # (target onset -> end-of-trial), matching the latency/congruency
+            # analysis; drop any landing on non-finite eye positions.
+            idx_use = np.asarray(first_saccade_indices.get(label, []), dtype=int)
+            if idx_use.size:
+                idx_use = idx_use[mask[idx_use]]
+        else:
+            idx_buf = []
+            sorted_pairs_xy = sorted(zip(saccade_frames_xy, saccade_indices_xy))
+            for f in frames:
+                lower_bound = max(f + plot_window[0], 0)
+                upper_bound = min(f + plot_window[-1], saccade_frames_xy.max())
+                for sf, idx in sorted_pairs_xy:
+                    if sf < lower_bound:
+                        continue
+                    elif sf <= upper_bound:
+                        idx_buf.append(idx)
+                        break
+                    else:
+                        break
+            idx_use = np.array(idx_buf, dtype=int)
         if idx_use.size == 0:
             continue
         sorted_data[label] = idx_use
@@ -736,7 +760,14 @@ def sort_saccades(
             ax_q.set_ylim(*Y_LIM)
             ax_q.set_xlabel("X (°)")
             ax_q.set_ylabel("Y (°)")
-            ax_q.set_title(f"{session_name}\n{eye_name} — {label} (n={n_cond})")
+            _win_note = (
+                "first saccade per trial, target onset → end-of-trial (reward window)"
+                if first_saccade_indices is not None
+                else f"first saccade per trial, fixed {saccade_config.saccade_win}s window"
+            )
+            ax_q.set_title(
+                f"{session_name}\n{eye_name} — {label} (n={n_cond})\n{_win_note}"
+            )
 
             cols = np.array([vector_to_rgb(a) for a in ang])
             ax_q.quiver(
@@ -755,22 +786,31 @@ def sort_saccades(
             plot_linear_histogram(ang, ax_l)
 
             if torsion_present and saccade_indices_theta is not None:
-                idx_buf_torsion: list[int] = []
-                sorted_pairs_theta = sorted(
-                    zip(saccade_frames_theta, saccade_indices_theta)
-                )
-                for f in frames:
-                    lower_bound = max(f + plot_window[0], 0)
-                    upper_bound = min(f + plot_window[-1], saccade_frames_theta.max())
-                    for sf, idx in sorted_pairs_theta:
-                        if sf < lower_bound:
-                            continue
-                        elif sf <= upper_bound:
-                            idx_buf_torsion.append(idx)
-                            break
-                        else:
-                            break
-                idx_use_t = np.array(idx_buf_torsion, dtype=int)
+                if first_saccade_indices_theta is not None:
+                    # First torsional saccade per trial in the same reward
+                    # window as the translational one; drop non-finite eyes.
+                    idx_use_t = np.asarray(
+                        first_saccade_indices_theta.get(label, []), dtype=int
+                    )
+                    if idx_use_t.size:
+                        idx_use_t = idx_use_t[mask[idx_use_t]]
+                else:
+                    idx_buf_torsion: list[int] = []
+                    sorted_pairs_theta = sorted(
+                        zip(saccade_frames_theta, saccade_indices_theta)
+                    )
+                    for f in frames:
+                        lower_bound = max(f + plot_window[0], 0)
+                        upper_bound = min(f + plot_window[-1], saccade_frames_theta.max())
+                        for sf, idx in sorted_pairs_theta:
+                            if sf < lower_bound:
+                                continue
+                            elif sf <= upper_bound:
+                                idx_buf_torsion.append(idx)
+                                break
+                            else:
+                                break
+                    idx_use_t = np.array(idx_buf_torsion, dtype=int)
                 for i in idx_use_t:
                     x, y = eye_pos[i, 0], eye_pos[i, 1]
                     arrow = FancyArrowPatch(


### PR DESCRIPTION
## Summary
This PR modifies the saccade visualization to use trial-aligned first saccades from the online reward window instead of fixed time windows, ensuring consistency with the latency and congruency analysis.

## Key Changes

- **Added optional parameters to `sort_saccades()`**: Two new optional parameters (`first_saccade_indices` and `first_saccade_indices_theta`) allow passing pre-computed first-saccade indices per trial and stimulus direction, enabling trial-aligned plotting instead of fixed-window searches.

- **Implemented `first_saccade_indices_by_direction()`**: New function in `prosaccade_session.py` that extracts the first saccade per trial within the online reward window (target onset to end-of-trial, capped at `max_latency`) and groups them by stimulus direction. This matches the exact saccades scored by the online task.

- **Updated per-condition plotting logic**: When `first_saccade_indices` is provided, the per-condition translational and torsional figures now plot exactly these first saccades instead of searching a fixed `saccade_win` window. The session-wide "All" figure remains unchanged and still shows every detected saccade.

- **Improved plot titles and documentation**: 
  - Updated the "All saccades" plot title to clarify it shows "not trial-aligned" saccades
  - Added per-condition plot subtitles indicating whether the window is trial-aligned (reward window) or fixed
  - Enhanced docstrings to explain the new parameters and their relationship to latency analysis

- **Updated `main()` in prosaccade_session.py**: Now calls `first_saccade_indices_by_direction()` for both translational and torsional streams and passes the results to `sort_saccades()`.

## Implementation Details

- The reward window is defined as the period from `go_frame` (target onset) to `end_of_trial_frame` (actual trial end), with a fallback to a flat `max_latency` cap if trial-end data is unavailable.
- Non-finite eye positions are filtered out using the existing `mask` array.
- The function supports both translational (`saccade_frames_xy`/`saccade_indices_xy`) and torsional (`saccade_frames_theta`/`saccade_indices_theta`) saccade streams via configurable `frames_key` and `indices_key` parameters.
- Stimulus direction grouping follows the same logic as `organize_stims()` (Left/Right for horizontal, Up/Down for vertical, or "All" if no directional data).

https://claude.ai/code/session_01Q3B3MdVwigYLvZx3nLqX4G