### PR TITLE
Consistent per-session trial window + lazy cv2 import (follow-up to #195)

### DIFF
--- a/Python/analysis/prosaccade_session.py
+++ b/Python/analysis/prosaccade_session.py
@@ -143,6 +143,41 @@ def find_first_saccade_per_trial(
     return np.array(latencies), np.array(congruent, dtype=bool)
 
 
+def session_max_trial_duration(
+    data: SessionData,
+    config,
+    mask: Optional[np.ndarray] = None,
+    default: float = 1.5,
+) -> float:
+    """Maximum trial duration for the session, in seconds, derived from data.
+
+    Uses the longest interval from target onset (``go_frame``) to trial end
+    (``end_of_trial_frame``). Trials in which the animal never made the
+    trial-ending saccade run to the task's time-out, so this maximum recovers
+    the response-window ceiling rather than a lone outlier. It is meant to be
+    computed once per session and used as the common upper time bound across
+    the PSTH, first-saccade latency, fraction-toward, and congruency analyses
+    so they all share the same window.
+
+    Falls back to ``default`` seconds if end-of-trial timing is unavailable.
+    """
+    if data.end_of_trial_frame is None:
+        warnings.warn(
+            "No end_of_trial data; using default max trial duration of "
+            f"{default}s for analysis windows."
+        )
+        return float(default)
+    dur = (
+        np.asarray(data.end_of_trial_frame) - np.asarray(data.go_frame)
+    ) / config.ttl_freq
+    if mask is not None:
+        dur = dur[mask]
+    dur = dur[np.isfinite(dur) & (dur > 0)]
+    if dur.size == 0:
+        return float(default)
+    return float(np.max(dur))
+
+
 def first_saccade_indices_by_direction(
     data: SessionData,
     saccades: Dict[str, np.ndarray],
@@ -586,9 +621,18 @@ def main(session_id: str) -> pd.DataFrame:
 
         }
     )
-    first_saccades = first_saccade_indices_by_direction(data, saccades, config)
+    mask_horizontal = data.go_direction_x != 0
+
+    # Single per-session max trial duration (target onset -> trial end),
+    # derived from the data, used as the common upper time bound across all
+    # of the analyses below so they share one window.
+    max_trial_time = session_max_trial_duration(data, config, mask=mask_horizontal)
+
+    first_saccades = first_saccade_indices_by_direction(
+        data, saccades, config, max_latency=max_trial_time
+    )
     first_saccades_theta = first_saccade_indices_by_direction(
-        data, saccades, config,
+        data, saccades, config, max_latency=max_trial_time,
         frames_key="saccade_frames_theta", indices_key="saccade_indices_theta",
     )
     sorted_data,left_angle,right_angle,fig_sorted, _ = sort_saccades(
@@ -600,15 +644,15 @@ def main(session_id: str) -> pd.DataFrame:
     if fig_sorted is not None:
         plt.close(fig_sorted)
 
-    mask_horizontal = data.go_direction_x != 0
     psth_centers, psth_rate, psth_ci, n_trials_psth = compute_saccade_psth(
-        data, saccades, config, mask=mask_horizontal
+        data, saccades, config, window=(-max_trial_time, max_trial_time),
+        mask=mask_horizontal,
     )
     latencies, congruent = find_first_saccade_per_trial(
-        data, saccades, config, mask=mask_horizontal
+        data, saccades, config, max_latency=max_trial_time, mask=mask_horizontal
     )
     latency_centers, fraction_toward, n_per_window = fraction_toward_target_by_latency(
-        latencies, congruent
+        latencies, congruent, window_span=(0.2, max_trial_time)
     )
 
     window = (0.15, 0.45)
@@ -626,7 +670,9 @@ def main(session_id: str) -> pd.DataFrame:
         config, window=window,
     )
 
-    latency_outcome = analyze_latency_by_outcome(data, saccades, config, mask=mask_horizontal)
+    latency_outcome = analyze_latency_by_outcome(
+        data, saccades, config, mask=mask_horizontal, max_latency=max_trial_time
+    )
     plot_latency_by_outcome(latency_outcome, config)
 
 

--- a/Python/eyehead/analysis.py
+++ b/Python/eyehead/analysis.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import cv2
 from matplotlib import cm, gridspec
 from matplotlib.patches import FancyArrowPatch
 from scipy.signal import medfilt
@@ -1412,6 +1411,7 @@ def extract_eye_position_from_dlc(
     pupil_area       : (N,) ndarray
         Pupil area in pixels squared (interpolated across blinks).
     """
+    import cv2  # local import: OpenCV is only needed for DLC pupil fitting
 
     # --- Extract keypoints ---
     pupil_points = dlc_data[


### PR DESCRIPTION
Follow-up to #195. Those two commits were pushed after #195 had already merged (only `a62069a` made it in), so they never landed on `main`. This PR brings them in.

## Changes

**1. Share one per-session max trial duration across all analyses** (`22c3447`)
Previously each stage used its own hard-coded time bound (fixed ±1.5 s PSTH window, 1.5 s latency cap, 1.0 s fraction-toward span), so the distributions were computed over inconsistent windows.

- Adds `session_max_trial_duration(data, config, mask=...)`, which derives one per-session ceiling from the data as `max(end_of_trial_frame − go_frame)`. Trials with no trial-ending saccade run to the task time-out, so this max recovers the response-window deadline rather than a lone outlier.
- `main()` computes it once (on the horizontal-trial population the analysis uses) and threads it as the common upper bound into:
  - PSTH window → `(−T, +T)`
  - `find_first_saccade_per_trial` / `analyze_latency_by_outcome` `max_latency` → `T`
  - `fraction_toward_target_by_latency` span → `(0.2, T)`
  - `first_saccade_indices_by_direction` (xy and θ streams) → `T`
- The `(0.15, 0.45) s` windowed-congruency epoch is intentionally left fixed as a deliberate early-response summary (it feeds only the third panel of the PSTH/congruency figure).

**2. Make the `cv2` import lazy** (`8d596e2`)
`cv2` (OpenCV) is only used by `extract_eye_position_from_dlc` (DeepLabCut pupil fitting), which isn't called by the session pipeline. Importing it at module top forced a hard OpenCV dependency at startup for code paths that never touch DLC (e.g. Bonsai online-tracker sessions), causing `ModuleNotFoundError: No module named 'cv2'`. Moved the import into the function so `eyehead.analysis` loads without OpenCV installed.

## Verification
- Both files compile.
- `session_max_trial_duration` unit-tested on synthetic trials: no-saccade timeout trials correctly set `T`, masking works, and it falls back to 1.5 s when end-of-trial timing is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3B3MdVwigYLvZx3nLqX4G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3B3MdVwigYLvZx3nLqX4G)_