### PR TITLE
Use configured saccade_win as the shared analysis window (follow-up to #196)

### DIFF
--- a/Python/analysis/prosaccade_session.py
+++ b/Python/analysis/prosaccade_session.py
@@ -623,10 +623,13 @@ def main(session_id: str) -> pd.DataFrame:
     )
     mask_horizontal = data.go_direction_x != 0
 
-    # Single per-session max trial duration (target onset -> trial end),
-    # derived from the data, used as the common upper time bound across all
-    # of the analyses below so they share one window.
-    max_trial_time = session_max_trial_duration(data, config, mask=mask_horizontal)
+    # Single response window used as the common upper time bound across all
+    # of the analyses below so they share one window. This is the configured
+    # ``saccade_win`` (the same value shown in the first figure's title), i.e.
+    # how long after target onset a first/response saccade is considered.
+    # (``session_max_trial_duration(data, config, mask=mask_horizontal)`` is
+    # available if you'd rather derive it per session from end_of_trial.)
+    max_trial_time = saccade_cfg.saccade_win
 
     first_saccades = first_saccade_indices_by_direction(
         data, saccades, config, max_latency=max_trial_time


### PR DESCRIPTION
Follow-up to #196.

Switches the common upper time bound shared across the analyses from the data-derived max trial duration to the **configured `saccade_win`** — the same response-window value already shown in the first figure's title (`SaccadeConfig.saccade_win`, default `0.7 s`). This makes every plot use one visible, adjustable knob and keeps them consistent with the sorted-saccade figures.

Threaded unchanged (via the single `max_trial_time` variable in `main()`) into:
- PSTH window → `(−saccade_win, +saccade_win)`
- `find_first_saccade_per_trial` / `analyze_latency_by_outcome` `max_latency`
- `fraction_toward_target_by_latency` span → `(0.2, saccade_win)`
- `first_saccade_indices_by_direction` (xy and θ streams)

The `(0.15, 0.45) s` windowed-congruency epoch remains fixed (deliberate early-response summary). `session_max_trial_duration` is kept in the module and referenced in a comment, so per-session derivation from `end_of_trial` is still available if preferred later.

Note: `saccade_win` is a fixed value (not per-session), so a first saccade later than `saccade_win` is excluded everywhere — intended if `saccade_win` is the response window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3B3MdVwigYLvZx3nLqX4G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3B3MdVwigYLvZx3nLqX4G)_